### PR TITLE
Switch back to ubuntu 22.04

### DIFF
--- a/.github/workflows/build-kata-os.yml
+++ b/.github/workflows/build-kata-os.yml
@@ -5,9 +5,9 @@ jobs:
   build:
     strategy:
       matrix:
-        runner: [ubuntu-latest, arm-8core-linux]
+        runner: [ubuntu-22.04, arm-8core-linux]
         include:
-          - runner: ubuntu-latest
+          - runner: ubuntu-22.04
             arch: amd64
             kernel_version: 6.8
           - runner: arm-8core-linux
@@ -42,7 +42,7 @@ jobs:
           path: /tmp/artifacts
           retention-days: 1
   release:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: build
     # Only create a release when a new tag is created
     if: ${{ startsWith(github.ref, 'refs/tags/') }}


### PR DESCRIPTION
Looks like ubuntu 24 (now the version used for ubuntu-latest) now prevent installing python packages globally with pip outside of virtualenv.
This switches back to ubuntu 22.04