### PR TITLE
[NODES-100] Add process to subcgroup /init if present

### DIFF
--- a/src/agent/rustjail/src/cgroups/fs/mod.rs
+++ b/src/agent/rustjail/src/cgroups/fs/mod.rs
@@ -1170,6 +1170,15 @@ impl Manager {
         })
     }
 
+    pub fn subcgroup(self: &Self) -> &str {
+        // Check if we're in a Docker-in-Docker setup by verifying:
+        // 1. We're using cgroups v2 (which restricts direct process control)
+        // 2. An "init" subdirectory exists (used by DinD for process delegation)
+        let is_dind = cgroups::hierarchies::is_cgroup2_unified_mode() &&
+            cgroups::hierarchies::auto().root().join(&self.cpath).join("init").exists();
+        if is_dind { "/init/" } else { "/" }
+    }
+
     fn get_paths_and_mounts(
         cpath: &str,
     ) -> Result<(HashMap<String, String>, HashMap<String, String>)> {

--- a/src/agent/rustjail/src/cgroups/systemd/dbus_client.rs
+++ b/src/agent/rustjail/src/cgroups/systemd/dbus_client.rs
@@ -19,7 +19,7 @@ pub trait SystemdInterface {
     fn kill_unit(&self) -> Result<()>;
     fn freeze_unit(&self) -> Result<()>;
     fn thaw_unit(&self) -> Result<()>;
-    fn add_process(&self, pid: i32) -> Result<()>;
+    fn add_process(&self, pid: i32, subcgroup: &str) -> Result<()>;
     fn get_version(&self) -> Result<String>;
     fn unit_exists(&self) -> Result<bool>;
 }
@@ -151,11 +151,10 @@ impl SystemdInterface for DBusClient {
         }
     }
 
-    fn add_process(&self, pid: i32) -> Result<()> {
+    fn add_process(&self, pid: i32, subcgroup: &str) -> Result<()> {
         let proxy = self.build_proxy()?;
-
         proxy
-            .attach_processes_to_unit(&self.unit_name, "/", &[pid as u32])
+            .attach_processes_to_unit(&self.unit_name, subcgroup, &[pid as u32])
             .context(format!(
                 "failed to add process into unit {}",
                 self.unit_name

--- a/src/agent/rustjail/src/cgroups/systemd/manager.rs
+++ b/src/agent/rustjail/src/cgroups/systemd/manager.rs
@@ -41,7 +41,8 @@ pub struct Manager {
 impl CgroupManager for Manager {
     fn apply(&self, pid: pid_t) -> Result<()> {
         if self.dbus_client.unit_exists()? {
-            self.dbus_client.add_process(pid)?;
+            let subcgroup = self.fs_manager.subcgroup();
+            self.dbus_client.add_process(pid, subcgroup)?;
         } else {
             self.dbus_client.start_unit(
                 (pid as u32).try_into().unwrap(),


### PR DESCRIPTION
dind creates a subcgroup init to circumvent permissions issues in cgroups v2 (see https://github.com/moby/moby/blob/master/hack/dind#L59 for details)
we must attach processes to this init subcgroup when exec'ing in the container for it to work 