### PR TITLE
Take cpu shares into accounts in micro vm sizing

### DIFF
--- a/.github/workflows/build-kata-os.yml
+++ b/.github/workflows/build-kata-os.yml
@@ -17,6 +17,9 @@ jobs:
     steps:
       - name: Check out repository code
         uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: ">=1.24.0"
       - name: Install dependencies
         run: sudo apt-get update && sudo apt-get install -y libelf-dev flex bison
       - name: Build Ubuntu image ${{ matrix.arch }}
@@ -26,13 +29,18 @@ jobs:
           cd tools/packaging/kernel
           sudo ./build-kernel.sh -v ${{ matrix.kernel_version }} setup
           sudo ./build-kernel.sh -v ${{ matrix.kernel_version }} build
+      - name: Build containerd-shim-kata-v2
+        run: |
+          cd src/runtime
+          make -j$(nproc) containerd-shim-v2
       - name: Bundle artifacts
         run: |
           cp tools/packaging/kernel/kata-linux-*/vmlinux /tmp/vmlinux
           cp tools/osbuilder/kata-containers-image-ubuntu.img /tmp/kata-containers-image-ubuntu.img
           cp sbom.cdx.gz /tmp/sbom.cdx.gz
+          cp src/runtime/containerd-shim-kata-v2 /tmp/containerd-shim-kata-v2
           mkdir -p /tmp/artifacts
-          zip -j /tmp/artifacts/artifacts-${{ matrix.arch }}.zip /tmp/vmlinux /tmp/kata-containers-image-ubuntu.img /tmp/sbom.cdx.gz
+          zip -j /tmp/artifacts/artifacts-${{ matrix.arch }}.zip /tmp/vmlinux /tmp/kata-containers-image-ubuntu.img /tmp/sbom.cdx.gz /tmp/containerd-shim-kata-v2
           cd /tmp/artifacts
           sha256sum artifacts-${{ matrix.arch }}.zip > checksum-${{ matrix.arch }}.sha256
       - name: Upload Artifact

--- a/src/runtime/pkg/oci/utils.go
+++ b/src/runtime/pkg/oci/utils.go
@@ -1338,7 +1338,7 @@ func (a *annotationConfiguration) setFloat32WithCheck(f func(float32) error) err
 // be added to the VM if sandbox annotations are provided with this sizing details
 func CalculateSandboxSizing(spec *specs.Spec) (numCPU float32, memSizeMB uint32) {
 	var memory, quota int64
-	var period uint64
+	var period, shares uint64
 	var err error
 
 	if spec == nil || spec.Annotations == nil {
@@ -1369,6 +1369,15 @@ func CalculateSandboxSizing(spec *specs.Spec) (numCPU float32, memSizeMB uint32)
 		}
 	}
 
+	annotation, ok = spec.Annotations[ctrAnnotations.SandboxCPUShares]
+	if ok {
+		shares, err = strconv.ParseUint(annotation, 10, 64)
+		if err != nil {
+			ociLog.Warningf("sandbox-sizing: failure to parse SandboxCPUShares: %s", annotation)
+			shares = 0
+		}
+	}
+
 	annotation, ok = spec.Annotations[ctrAnnotations.SandboxMem]
 	if ok {
 		memory, err = strconv.ParseInt(annotation, 10, 64)
@@ -1378,14 +1387,14 @@ func CalculateSandboxSizing(spec *specs.Spec) (numCPU float32, memSizeMB uint32)
 		}
 	}
 
-	return calculateVMResources(period, quota, memory)
+	return calculateVMResources(period, quota, shares, memory)
 }
 
 // CalculateContainerSizing will calculate the number of CPUs and amount of memory that is needed
 // based on the provided LinuxResources
 func CalculateContainerSizing(spec *specs.Spec) (numCPU float32, memSizeMB uint32) {
 	var memory, quota int64
-	var period uint64
+	var period, shares uint64
 
 	if spec == nil || spec.Linux == nil || spec.Linux.Resources == nil {
 		return 0, 0
@@ -1393,20 +1402,25 @@ func CalculateContainerSizing(spec *specs.Spec) (numCPU float32, memSizeMB uint3
 
 	resources := spec.Linux.Resources
 
-	if resources.CPU != nil && resources.CPU.Quota != nil && resources.CPU.Period != nil {
-		quota = *resources.CPU.Quota
-		period = *resources.CPU.Period
+	if resources.CPU != nil {
+		if resources.CPU.Quota != nil && resources.CPU.Period != nil {
+			quota = *resources.CPU.Quota
+			period = *resources.CPU.Period
+		}
+		if resources.CPU.Shares != nil {
+			shares = *resources.CPU.Shares
+		}
 	}
 
 	if resources.Memory != nil && resources.Memory.Limit != nil {
 		memory = *resources.Memory.Limit
 	}
 
-	return calculateVMResources(period, quota, memory)
+	return calculateVMResources(period, quota, shares, memory)
 }
 
-func calculateVMResources(period uint64, quota int64, memory int64) (numCPU float32, memSizeMB uint32) {
-	numCPU = vcutils.CalculateCPUsF(quota, period)
+func calculateVMResources(period uint64, quota int64, shares uint64, memory int64) (numCPU float32, memSizeMB uint32) {
+	numCPU = vcutils.CalculateCPUsF(quota, period, shares)
 
 	if memory < 0 {
 		// While spec allows for a negative value to indicate unconstrained, we don't

--- a/src/runtime/virtcontainers/sandbox.go
+++ b/src/runtime/virtcontainers/sandbox.go
@@ -2465,7 +2465,7 @@ func (s *Sandbox) calculateSandboxCPUs() (float32, error) {
 
 		if cpu := c.Resources.CPU; cpu != nil {
 			if cpu.Period != nil && cpu.Quota != nil {
-				floatCPU += utils.CalculateCPUsF(*cpu.Quota, *cpu.Period)
+				floatCPU += utils.CalculateCPUsF(*cpu.Quota, *cpu.Period, 0)
 			}
 
 			set, err := cpuset.Parse(cpu.Cpus)

--- a/src/runtime/virtcontainers/utils/utils.go
+++ b/src/runtime/virtcontainers/utils/utils.go
@@ -130,7 +130,7 @@ func CalculateCPUsF(quota int64, period, shares uint64) float32 {
 		return float32(quota) / float32(period)
 	}
 
-	// If not CPU limit is set (or no CPU limit is enforced),
+	// If CPU limit is not set (or no CPU limit is enforced),
 	// Default to the CPU requests (i.e. CPU shares)
 	return float32(shares) / 1024.0
 }

--- a/src/runtime/virtcontainers/utils/utils.go
+++ b/src/runtime/virtcontainers/utils/utils.go
@@ -121,8 +121,8 @@ func WriteToFile(path string, data []byte) error {
 	return nil
 }
 
-// CalculateCPUsF converts CPU quota and period to a fraction number
-func CalculateCPUsF(quota int64, period uint64) float32 {
+// CalculateCPUsF converts CPU quota and period to a fraction number, or default to the CPU shares
+func CalculateCPUsF(quota int64, period, shares uint64) float32 {
 	// If quota is -1, it means the CPU resource request is
 	// unconstrained.  In that case, we don't currently assign
 	// additional CPUs.
@@ -130,7 +130,9 @@ func CalculateCPUsF(quota int64, period uint64) float32 {
 		return float32(quota) / float32(period)
 	}
 
-	return 0
+	// If not CPU limit is set (or no CPU limit is enforced),
+	// Default to the CPU requests (i.e. CPU shares)
+	return float32(shares) / 1024.0
 }
 
 // GetVirtDriveName returns the disk name format for virtio-blk

--- a/src/runtime/virtcontainers/utils/utils_test.go
+++ b/src/runtime/virtcontainers/utils/utils_test.go
@@ -150,20 +150,28 @@ func TestWriteToFile(t *testing.T) {
 func TestCalculateCPUsF(t *testing.T) {
 	assert := assert.New(t)
 
-	n := CalculateCPUsF(1, 1)
+	n := CalculateCPUsF(1, 1, 0)
 	expected := float32(1)
 	assert.Equal(n, expected)
 
-	n = CalculateCPUsF(1, 0)
+	n = CalculateCPUsF(1, 0, 0)
 	expected = float32(0)
 	assert.Equal(n, expected)
 
-	n = CalculateCPUsF(-1, 1)
+	n = CalculateCPUsF(-1, 1, 0)
 	expected = float32(0)
 	assert.Equal(n, expected)
 
-	n = CalculateCPUsF(500, 1000)
+	n = CalculateCPUsF(500, 1000, 0)
 	expected = float32(0.5)
+	assert.Equal(n, expected)
+
+	n = CalculateCPUsF(500, 1000, 1024)
+	expected = float32(0.5)
+	assert.Equal(n, expected)
+
+	n = CalculateCPUsF(0, 0, 1024)
+	expected = float32(1)
 	assert.Equal(n, expected)
 }
 


### PR DESCRIPTION
Take CPU shares into account when computing the sandbox size

microVM sandbox resources are computed from pod sandbox annotations.
In particular, the number of vCPU is calculated by using CPU quota
divided by CPU period. However, on clusters where CFS quotas are disabled,
or if the pod doesn't specify any limit, the compute size is 0.
When using resource hot plugging, the value value will be the size of the
CPU set, which doesn't impact the performance of the microVM pod. But when
using static sandbox management, the computed value will be 0 and the
microVM will be dramatically undersized.

This change takes into account CPU shares while computing the number of vCPU,
and default the CPU Shares/1024 in case CPU quota and/or periods are zeros.