### PR TITLE
[Github Actions] Build kata-static.tar.xz

### DIFF
--- a/.github/workflows/build-kata-os.yml
+++ b/.github/workflows/build-kata-os.yml
@@ -57,7 +57,7 @@ jobs:
           retention-days: 1
   release:
     runs-on: ubuntu-22.04
-    needs: build
+    needs: [build, build-kata-static-tarball-amd64]
     # Only create a release when a new tag is created
     if: ${{ startsWith(github.ref, 'refs/tags/') }}
     steps:
@@ -71,6 +71,10 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: artifacts-arm64
+      - name: Download kata-static-tarball-amd64
+        uses: actions/download-artifact@v4
+        with:
+          name: kata-static-tarball-amd64
       - name: "Create New Release"
         env:
           GH_TOKEN: ${{ secrets.WORKFLOW_TOKEN }}
@@ -82,4 +86,5 @@ jobs:
           gh release upload "${RELEASE_VERSION}" artifacts-arm64.zip
           gh release upload "${RELEASE_VERSION}" checksum-amd64.sha256
           gh release upload "${RELEASE_VERSION}" checksum-arm64.sha256
+          gh release upload "${RELEASE_VERSION}" kata-static.tar.xz
           gh release edit ${RELEASE_VERSION} --verify-tag	--draft=false

--- a/.github/workflows/build-kata-os.yml
+++ b/.github/workflows/build-kata-os.yml
@@ -2,6 +2,12 @@ name: Build Kata OS
 run-name: Build Kata OS
 on: [push]
 jobs:
+
+  build-kata-static-tarball-amd64:
+    uses: ./.github/workflows/build-kata-static-tarball-amd64.yaml
+    with:
+      stage: release
+
   build:
     strategy:
       matrix:

--- a/.github/workflows/build-kata-static-tarball-amd64.yaml
+++ b/.github/workflows/build-kata-static-tarball-amd64.yaml
@@ -34,7 +34,7 @@ jobs:
           #- busybox
           - cloud-hypervisor
           - cloud-hypervisor-glibc
-          #- coco-guest-components
+          - coco-guest-components
           - csi-kata-directvolume
           - firecracker
           - genpolicy

--- a/.github/workflows/build-kata-static-tarball-amd64.yaml
+++ b/.github/workflows/build-kata-static-tarball-amd64.yaml
@@ -26,9 +26,6 @@ jobs:
     runs-on: ubuntu-22.04
     permissions:
       contents: read
-      packages: write
-      id-token: write
-      attestations: write
     strategy:
       matrix:
         asset:
@@ -66,14 +63,6 @@ jobs:
     env:
       PERFORM_ATTESTATION: ${{ matrix.asset == 'agent' && inputs.push-to-registry == 'yes' && 'yes' || 'no' }}
     steps:
-      - name: Login to Kata Containers quay.io
-        if: ${{ inputs.push-to-registry == 'yes' }}
-        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
-        with:
-          registry: quay.io
-          username: ${{ secrets.QUAY_DEPLOYER_USERNAME }}
-          password: ${{ secrets.QUAY_DEPLOYER_PASSWORD }}
-
       - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.commit-hash }}
@@ -109,19 +98,6 @@ jobs:
           oci_image="$(<"build/${{ matrix.asset }}-oci-image")"
           echo "oci-name=${oci_image%@*}" >> "$GITHUB_OUTPUT"
           echo "oci-digest=${oci_image#*@}" >> "$GITHUB_OUTPUT"
-
-      - uses: oras-project/setup-oras@5c0b487ce3fe0ce3ab0d034e63669e426e294e4d # v1.2.2
-        if: ${{ env.PERFORM_ATTESTATION == 'yes' }}
-        with:
-          version: "1.2.0"
-
-      # for pushing attestations to the registry
-      - uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
-        if: ${{ env.PERFORM_ATTESTATION == 'yes' }}
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: actions/attest-build-provenance@v1
         if: ${{ env.PERFORM_ATTESTATION == 'yes' }}
@@ -161,14 +137,6 @@ jobs:
           - rootfs-nvidia-gpu-initrd
           - rootfs-nvidia-gpu-confidential-initrd
     steps:
-      - name: Login to Kata Containers quay.io
-        if: ${{ inputs.push-to-registry == 'yes' }}
-        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
-        with:
-          registry: quay.io
-          username: ${{ secrets.QUAY_DEPLOYER_USERNAME }}
-          password: ${{ secrets.QUAY_DEPLOYER_PASSWORD }}
-
       - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.commit-hash }}
@@ -213,48 +181,11 @@ jobs:
           retention-days: 15
           if-no-files-found: error
 
-  # We don't need the binaries installed in the rootfs as part of the release tarball, so can delete them now we've built the rootfs
-  remove-rootfs-binary-artifacts:
-    runs-on: ubuntu-22.04
-    needs: build-asset-rootfs
-    strategy:
-      matrix:
-        asset:
-          - busybox
-          - coco-guest-components
-          - kernel-nvidia-gpu-headers
-          - kernel-nvidia-gpu-confidential-headers
-          - pause-image
-    steps:
-      - uses: geekyeggo/delete-artifact@f275313e70c08f6120db482d7a6b98377786765b # v5.1.0
-        with:
-          name: kata-artifacts-amd64-${{ matrix.asset}}${{ inputs.tarball-suffix }}
-
-  # We don't need the binaries installed in the rootfs as part of the release tarball, so can delete them now we've built the rootfs
-  remove-rootfs-binary-artifacts-for-release:
-    runs-on: ubuntu-22.04
-    needs: build-asset-rootfs
-    strategy:
-      matrix:
-        asset:
-          - agent
-    steps:
-      - uses: geekyeggo/delete-artifact@f275313e70c08f6120db482d7a6b98377786765b # v5.1.0
-        if: ${{ inputs.stage == 'release' }}
-        with:
-          name: kata-artifacts-amd64-${{ matrix.asset}}${{ inputs.tarball-suffix }}
 
   build-asset-shim-v2:
     runs-on: ubuntu-22.04
-    needs: [build-asset, build-asset-rootfs, remove-rootfs-binary-artifacts, remove-rootfs-binary-artifacts-for-release]
+    needs: [build-asset, build-asset-rootfs]
     steps:
-      - name: Login to Kata Containers quay.io
-        if: ${{ inputs.push-to-registry == 'yes' }}
-        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
-        with:
-          registry: quay.io
-          username: ${{ secrets.QUAY_DEPLOYER_USERNAME }}
-          password: ${{ secrets.QUAY_DEPLOYER_PASSWORD }}
 
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/build-kata-static-tarball-amd64.yaml
+++ b/.github/workflows/build-kata-static-tarball-amd64.yaml
@@ -29,7 +29,7 @@ jobs:
     strategy:
       matrix:
         asset:
-          #- agent
+          - agent
           - agent-ctl
           #- busybox
           - cloud-hypervisor
@@ -48,7 +48,7 @@ jobs:
           - nydus
           - ovmf
           - ovmf-sev
-          #- pause-image
+          - pause-image
           - qemu
           - qemu-snp-experimental
           - qemu-tdx-experimental

--- a/.github/workflows/build-kata-static-tarball-amd64.yaml
+++ b/.github/workflows/build-kata-static-tarball-amd64.yaml
@@ -29,12 +29,12 @@ jobs:
     strategy:
       matrix:
         asset:
-          - agent
+          #- agent
           - agent-ctl
-          - busybox
+          #- busybox
           - cloud-hypervisor
           - cloud-hypervisor-glibc
-          - coco-guest-components
+          #- coco-guest-components
           - csi-kata-directvolume
           - firecracker
           - genpolicy
@@ -48,7 +48,7 @@ jobs:
           - nydus
           - ovmf
           - ovmf-sev
-          - pause-image
+          #- pause-image
           - qemu
           - qemu-snp-experimental
           - qemu-tdx-experimental
@@ -111,15 +111,6 @@ jobs:
         with:
           name: kata-artifacts-amd64-${{ matrix.asset }}${{ inputs.tarball-suffix }}
           path: kata-build/kata-static-${{ matrix.asset }}.tar.xz
-          retention-days: 15
-          if-no-files-found: error
-
-      - name: store-extratarballs-artifact ${{ matrix.asset }}
-        if: ${{ startsWith(matrix.asset, 'kernel-nvidia-gpu') }}
-        uses: actions/upload-artifact@v4
-        with:
-          name: kata-artifacts-amd64-${{ matrix.asset }}-headers${{ inputs.tarball-suffix }}
-          path: kata-build/kata-static-${{ matrix.asset }}-headers.tar.xz
           retention-days: 15
           if-no-files-found: error
 

--- a/tools/osbuilder/rootfs-builder/alpine/Dockerfile.in
+++ b/tools/osbuilder/rootfs-builder/alpine/Dockerfile.in
@@ -15,6 +15,7 @@ RUN apk update && apk add --no-cache \
     cmake \
     coreutils \
     curl \
+    findutils \
     g++ \
     gcc \
     git \


### PR DESCRIPTION
This PR updates the existing Github Actions that is used to build the Kata OS (`Build Kata OS`) to execute a version of upstreams `CI | Build kata-static tarball for amd64` workflow. 

I've modified `CI | Build kata-static tarball for amd64` as follows: 
* Remove the use of Action's that are not published by the Datadog org or Github
* Without `geekyeggo/delete-artifact`, I'm simply not building `agent`, `busybox`,  `coco-guest-components`,  `pause-image`, and the `kernel-nvidia-gpu*-header` artifacts 
* Dropped all of the `quay.io` logins as they are not required. 
* Updated the existing `release` action to depend on the static tarball build job & to download it and add it to the release. 
* Adding `findutils` to the Alpine container so [our customization](https://github.com/DataDog/kata-containers/commit/b5516eed180f4022f25c8a7cbe23913315d5286d) that relies on `-printf` works. 