### PR TITLE
runtime-go: fixes early closed stdout/err on exec w/o stdin option

### DIFF
--- a/src/runtime/virtcontainers/iostream.go
+++ b/src/runtime/virtcontainers/iostream.go
@@ -78,19 +78,11 @@ func (s *stdinStream) Close() error {
 }
 
 func (s *stdoutStream) Read(data []byte) (n int, err error) {
-	if s.closed {
-		return 0, errors.New("stream closed")
-	}
-
 	// can not pass context to Read(), so use background context
 	return s.sandbox.agent.readProcessStdout(context.Background(), s.container, s.process, data)
 }
 
 func (s *stderrStream) Read(data []byte) (n int, err error) {
-	if s.closed {
-		return 0, errors.New("stream closed")
-	}
-
 	// can not pass context to Read(), so use background context
 	return s.sandbox.agent.readProcessStderr(context.Background(), s.container, s.process, data)
 }


### PR DESCRIPTION
An early call to closing the stdin channel made the stdout & stderr also closed. This waits for stdout & stderr to be properly finished by reading the whole buffer before closing everything. On the other, this also fixes a race condition where it was impossible to run multiple execs until the other one was over. This moves the lock only where it is necessary without locking exec processes.

Fixes #10387

Jira: NODES-236