### PR TITLE
Use GITHUB_TOKEN secret to upload release artefacts

### DIFF
--- a/.github/workflows/build-kata-os.yml
+++ b/.github/workflows/build-kata-os.yml
@@ -1,6 +1,8 @@
 name: Build Kata OS
 run-name: Build Kata OS
 on: [push]
+permissions:
+  contents: write
 jobs:
   build:
     strategy:
@@ -67,7 +69,7 @@ jobs:
           name: artifacts-arm64
       - name: "Create New Release"
         env:
-          GH_TOKEN: ${{ secrets.WORKFLOW_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           RELEASE_VERSION=$(echo ${{ github.ref }} | sed 's/refs\/tags\///')
           echo "Creating release $RELEASE_VERSION"


### PR DESCRIPTION
The WORKFLOW_TOKEN no longer seems to exist, so artefact uploads fail. Use the built-in token instead.