### PR TITLE
Map stdin to /dev/null for non-interactive exec

### DIFF
--- a/src/agent/rustjail/src/process.rs
+++ b/src/agent/rustjail/src/process.rs
@@ -175,9 +175,12 @@ impl Process {
             } else {
                 info!(logger, "created console socket!");
 
-                let (stdin, pstdin) = unistd::pipe2(OFlag::O_CLOEXEC)?;
-                p.parent_stdin = Some(pstdin);
-                p.stdin = Some(stdin);
+                let devnull = std::fs::OpenOptions::new()
+                    .read(true)
+                    .open("/dev/null")
+                    .map_err(|e| Errno::from_i32(e.raw_os_error().unwrap_or(libc::EIO)))?;
+                p.stdin = Some(devnull.as_raw_fd());
+                p.extra_files.push(devnull);
 
                 // These pipes are necessary as the stdout/stderr of the child process
                 // cannot be a socket. Otherwise, some images relying on the /dev/stdout(stderr)


### PR DESCRIPTION
Fixes blocked processes lanched through kubectl exec that read from stdin even in non-interactive mode. 

Jira: NODES-271