### PR TITLE
Revert "Map stdin to /dev/null for non-interactive exec (#30)"

### DIFF
--- a/src/agent/rustjail/src/process.rs
+++ b/src/agent/rustjail/src/process.rs
@@ -175,12 +175,9 @@ impl Process {
             } else {
                 info!(logger, "created console socket!");
 
-                let devnull = std::fs::OpenOptions::new()
-                    .read(true)
-                    .open("/dev/null")
-                    .map_err(|e| Errno::from_i32(e.raw_os_error().unwrap_or(libc::EIO)))?;
-                p.stdin = Some(devnull.as_raw_fd());
-                p.extra_files.push(devnull);
+                let (stdin, pstdin) = unistd::pipe2(OFlag::O_CLOEXEC)?;
+                p.parent_stdin = Some(pstdin);
+                p.stdin = Some(stdin);
 
                 // These pipes are necessary as the stdout/stderr of the child process
                 // cannot be a socket. Otherwise, some images relying on the /dev/stdout(stderr)


### PR DESCRIPTION
This reverts commit 5633fac2e86e66116860979a258b2cc599689f6d.

Reverts the "fix" for stuck-stdin (NODES-271) as it breaks `kubectl cp`.