### PR TITLE
ci: compile `shim-rs` in gitlab ci and gha

### DIFF
--- a/.github/workflows/build-kata-static-tarball-amd64.yaml
+++ b/.github/workflows/build-kata-static-tarball-amd64.yaml
@@ -317,10 +317,49 @@ jobs:
           retention-days: 15
           if-no-files-found: error
 
+  build-asset-shim-rs:
+    name: build-asset-shim-rs
+    runs-on: ubuntu-22.04
+    needs: []
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: ${{ inputs.commit-hash }}
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Rebase atop of the latest target branch
+        run: |
+          ./tests/git-helper.sh "rebase-atop-of-the-latest-target-branch"
+        env:
+          TARGET_BRANCH: ${{ inputs.target-branch }}
+      - name: Install Rust toolchain
+        run: |
+          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain 1.88
+          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+      - name: Build shim-rs
+        run: |
+          sudo apt-get update -q && sudo apt-get install -yq musl-tools
+          rustup target add x86_64-unknown-linux-musl
+          cd src/runtime-rs
+          make clean-generated-files
+          make PREFIX=/opt/kata QEMUCMD=qemu-system-x86_64
+          make PREFIX=/opt/kata DESTDIR=/tmp/kata-rs-build install
+          cd /tmp/kata-rs-build
+          tar --zstd -cf /tmp/kata-static-shim-rs.tar.zst .
+      - name: store-artifact shim-rs
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: kata-artifacts-amd64-shim-rs${{ inputs.tarball-suffix }}
+          path: /tmp/kata-static-shim-rs.tar.zst
+          retention-days: 15
+          if-no-files-found: error
+
   create-kata-tarball:
     name: create-kata-tarball
     runs-on: ubuntu-22.04
-    needs: [build-asset, build-asset-rootfs, build-asset-shim-v2]
+    needs: [build-asset, build-asset-rootfs, build-asset-shim-v2, build-asset-shim-rs]
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/build-kata-static-tarball-arm64.yaml
+++ b/.github/workflows/build-kata-static-tarball-arm64.yaml
@@ -296,10 +296,49 @@ jobs:
           retention-days: 15
           if-no-files-found: error
 
+  build-asset-shim-rs:
+    name: build-asset-shim-rs
+    runs-on: ubuntu-24.04-arm
+    needs: []
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: ${{ inputs.commit-hash }}
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Rebase atop of the latest target branch
+        run: |
+          ./tests/git-helper.sh "rebase-atop-of-the-latest-target-branch"
+        env:
+          TARGET_BRANCH: ${{ inputs.target-branch }}
+      - name: Install Rust toolchain
+        run: |
+          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain 1.88
+          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+      - name: Build shim-rs
+        run: |
+          sudo apt-get update -q && sudo apt-get install -yq musl-tools
+          rustup target add aarch64-unknown-linux-musl
+          cd src/runtime-rs
+          make clean-generated-files
+          ARCH=aarch64 make PREFIX=/opt/kata QEMUCMD=qemu-system-aarch64
+          ARCH=aarch64 make PREFIX=/opt/kata DESTDIR=/tmp/kata-rs-build install
+          cd /tmp/kata-rs-build
+          tar --zstd -cf /tmp/kata-static-shim-rs.tar.zst .
+      - name: store-artifact shim-rs
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: kata-artifacts-arm64-shim-rs${{ inputs.tarball-suffix }}
+          path: /tmp/kata-static-shim-rs.tar.zst
+          retention-days: 15
+          if-no-files-found: error
+
   create-kata-tarball:
     name: create-kata-tarball
     runs-on: ubuntu-24.04-arm
-    needs: [build-asset, build-asset-rootfs, build-asset-shim-v2]
+    needs: [build-asset, build-asset-rootfs, build-asset-shim-v2, build-asset-shim-rs]
     permissions:
       contents: read
       packages: write

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -83,6 +83,38 @@ build-shim-arm64:
       - src/runtime/containerd-shim-kata-v2-arm64
     expire_in: 1 week
 
+build-shim-rust-amd64:
+  image: registry.ddbuild.io/images/mirror/library/rust:1.88
+  stage: build
+  tags: [ "arch:amd64" ]
+  script:
+    - apt-get update -q && apt-get install -yq musl-tools
+    - rustup target add x86_64-unknown-linux-musl
+    - cd src/runtime-rs
+    - make clean-generated-files
+    - make PREFIX=/opt/kata QEMUCMD=qemu-system-x86_64
+    - cp ../../target/x86_64-unknown-linux-musl/release/containerd-shim-kata-v2 containerd-shim-kata-v2-rust-amd64
+  artifacts:
+    paths:
+      - src/runtime-rs/containerd-shim-kata-v2-rust-amd64
+    expire_in: 1 week
+
+build-shim-rust-arm64:
+  image: registry.ddbuild.io/images/mirror/library/rust:1.88
+  stage: build
+  tags: [ "arch:arm64" ]
+  script:
+    - apt-get update -q && apt-get install -yq musl-tools
+    - rustup target add aarch64-unknown-linux-musl
+    - cd src/runtime-rs
+    - make clean-generated-files
+    - ARCH=aarch64 make PREFIX=/opt/kata QEMUCMD=qemu-system-aarch64
+    - cp ../../target/aarch64-unknown-linux-musl/release/containerd-shim-kata-v2 containerd-shim-kata-v2-rust-arm64
+  artifacts:
+    paths:
+      - src/runtime-rs/containerd-shim-kata-v2-rust-arm64
+    expire_in: 1 week
+
 publish-artifacts:
   image: registry.ddbuild.io/$CI_PROJECT_NAME/ci:$CI_IMAGE
   stage: publish
@@ -92,11 +124,15 @@ publish-artifacts:
   dependencies:
     - "build-kernel-amd64"
     - "build-kernel-arm64"
+    - "build-shim-rust-amd64"
+    - "build-shim-rust-arm64"
   variables:
     GIT_STRATEGY: none
   script:
     - aws s3 cp tools/packaging/kernel/vmlinux-amd64 s3://kata-containers-ci-artifacts/$CI_COMMIT_REF_NAME/amd64/vmlinux
     - aws s3 cp tools/packaging/kernel/vmlinux-arm64 s3://kata-containers-ci-artifacts/$CI_COMMIT_REF_NAME/arm64/vmlinux
+    - aws s3 cp src/runtime-rs/containerd-shim-kata-v2-rust-amd64 s3://kata-containers-ci-artifacts/$CI_COMMIT_REF_NAME/amd64/containerd-shim-kata-v2
+    - aws s3 cp src/runtime-rs/containerd-shim-kata-v2-rust-arm64 s3://kata-containers-ci-artifacts/$CI_COMMIT_REF_NAME/arm64/containerd-shim-kata-v2
     - echo $CI_COMMIT_REF_NAME > LATEST && aws s3 cp LATEST s3://kata-containers-ci-artifacts/LATEST
 
 publish-oci-image:


### PR DESCRIPTION
## Summary

- Add `build-shim-rust-amd64` and `build-shim-rust-arm64` jobs to `.gitlab-ci.yml`
- Add `build-asset-shim-rs` job to GitHub Actions for both amd64 and arm64
- Update `publish-artifacts` and `create-kata-tarball` to include Rust shim binaries

### Motivation

The Rust containerd shim (`kata-agent-rs` / shim-rs) needs to be built and included in the static tarball artifact. This CI change ensures both the GitLab and GitHub pipelines compile and package it alongside the existing Go shim.

### Test

- [ ] GitLab CI: `build-shim-rust-amd64` and `build-shim-rust-arm64` jobs pass
- [ ] GitHub Actions: `build-asset-shim-rs` step succeeds on both architectures
- [ ] Tarball artifact contains the Rust shim binary