### PR TITLE
runtime-rs: add netkit endpoint support

### DIFF
--- a/src/runtime-rs/crates/resource/src/network/endpoint/endpoint_persist.rs
+++ b/src/runtime-rs/crates/resource/src/network/endpoint/endpoint_persist.rs
@@ -34,6 +34,12 @@ pub struct VethEndpointState {
 }
 
 #[derive(Serialize, Deserialize, Clone, Default)]
+pub struct NetkitEndpointState {
+    pub if_name: String,
+    pub network_qos: bool,
+}
+
+#[derive(Serialize, Deserialize, Clone, Default)]
 pub struct IpVlanEndpointState {
     pub if_name: String,
     pub network_qos: bool,
@@ -54,6 +60,7 @@ pub struct VhostUserEndpointState {
 pub struct EndpointState {
     pub physical_endpoint: Option<PhysicalEndpointState>,
     pub veth_endpoint: Option<VethEndpointState>,
+    pub netkit_endpoint: Option<NetkitEndpointState>,
     pub ipvlan_endpoint: Option<IpVlanEndpointState>,
     pub macvlan_endpoint: Option<MacvlanEndpointState>,
     pub vlan_endpoint: Option<VlanEndpointState>,

--- a/src/runtime-rs/crates/resource/src/network/endpoint/mod.rs
+++ b/src/runtime-rs/crates/resource/src/network/endpoint/mod.rs
@@ -8,6 +8,8 @@ mod physical_endpoint;
 pub use physical_endpoint::PhysicalEndpoint;
 mod veth_endpoint;
 pub use veth_endpoint::VethEndpoint;
+mod netkit_endpoint;
+pub use netkit_endpoint::NetkitEndpoint;
 mod ipvlan_endpoint;
 pub use ipvlan_endpoint::IPVlanEndpoint;
 mod vlan_endpoint;

--- a/src/runtime-rs/crates/resource/src/network/endpoint/netkit_endpoint.rs
+++ b/src/runtime-rs/crates/resource/src/network/endpoint/netkit_endpoint.rs
@@ -1,0 +1,115 @@
+// Copyright (c) 2019-2022 Alibaba Cloud
+// Copyright (c) 2019-2022 Ant Group
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+use std::io::{self, Error};
+use std::sync::Arc;
+
+use anyhow::{Context, Result};
+use async_trait::async_trait;
+use hypervisor::device::device_manager::{do_handle_device, DeviceManager};
+use hypervisor::device::driver::NetworkConfig;
+use hypervisor::device::{DeviceConfig, DeviceType};
+use hypervisor::{Hypervisor, NetworkDevice};
+use tokio::sync::RwLock;
+
+use super::endpoint_persist::{EndpointState, NetkitEndpointState};
+use super::Endpoint;
+use crate::network::{utils, NetworkPair};
+
+#[derive(Debug)]
+pub struct NetkitEndpoint {
+    pub(crate) net_pair: NetworkPair,
+    pub(crate) d: Arc<RwLock<DeviceManager>>,
+}
+
+impl NetkitEndpoint {
+    pub async fn new(
+        d: &Arc<RwLock<DeviceManager>>,
+        handle: &rtnetlink::Handle,
+        name: &str,
+        idx: u32,
+        model: &str,
+        queues: usize,
+    ) -> Result<Self> {
+        let net_pair = NetworkPair::new(handle, idx, name, model, queues)
+            .await
+            .context("new network interface pair failed.")?;
+
+        Ok(NetkitEndpoint {
+            net_pair,
+            d: d.clone(),
+        })
+    }
+
+    fn get_network_config(&self) -> Result<NetworkConfig> {
+        let iface = &self.net_pair.tap.tap_iface;
+        let guest_mac = utils::parse_mac(&iface.hard_addr).ok_or_else(|| {
+            Error::new(
+                io::ErrorKind::InvalidData,
+                format!("hard_addr {}", &iface.hard_addr),
+            )
+        })?;
+
+        Ok(NetworkConfig {
+            host_dev_name: iface.name.clone(),
+            virt_iface_name: self.net_pair.virt_iface.name.clone(),
+            guest_mac: Some(guest_mac),
+            ..Default::default()
+        })
+    }
+}
+
+#[async_trait]
+impl Endpoint for NetkitEndpoint {
+    async fn name(&self) -> String {
+        self.net_pair.virt_iface.name.clone()
+    }
+
+    async fn hardware_addr(&self) -> String {
+        self.net_pair.tap.tap_iface.hard_addr.clone()
+    }
+
+    async fn attach(&self) -> Result<()> {
+        self.net_pair
+            .add_network_model()
+            .await
+            .context("add network model")?;
+
+        let config = self.get_network_config().context("get network config")?;
+        do_handle_device(&self.d, &DeviceConfig::NetworkCfg(config))
+            .await
+            .context("do handle network netkit endpoint device failed.")?;
+
+        Ok(())
+    }
+
+    async fn detach(&self, h: &dyn Hypervisor) -> Result<()> {
+        self.net_pair
+            .del_network_model()
+            .await
+            .context("del network model failed.")?;
+
+        let config = self.get_network_config().context("get network config")?;
+        h.remove_device(DeviceType::Network(NetworkDevice {
+            config,
+            ..Default::default()
+        }))
+        .await
+        .context("remove netkit endpoint device by hypervisor failed.")?;
+
+        Ok(())
+    }
+
+    async fn save(&self) -> Option<EndpointState> {
+        Some(EndpointState {
+            netkit_endpoint: Some(NetkitEndpointState {
+                if_name: self.net_pair.virt_iface.name.clone(),
+                network_qos: self.net_pair.network_qos,
+            }),
+            ..Default::default()
+        })
+    }
+}

--- a/src/runtime-rs/crates/resource/src/network/network_with_netns.rs
+++ b/src/runtime-rs/crates/resource/src/network/network_with_netns.rs
@@ -280,10 +280,22 @@ async fn create_endpoint(
                 Arc::new(ret)
             }
             "netkit" => {
-                // L3 mode netkit devices have no MAC address and are not supported.
-                if attrs.hardware_addr.is_empty() {
+                let is_l3 = link
+                    .as_any()
+                    .downcast_ref::<link::Netkit>()
+                    .and_then(|n| n.mode)
+                    .map_or_else(
+                        || {
+                            attrs.hardware_addr.is_empty()
+                            // L3 devices have no MAC address, so check for all-zero.
+                            // https://github.com/torvalds/linux/blob/master/drivers/net/netkit.c
+                                || attrs.hardware_addr.iter().all(|&b| b == 0)
+                        },
+                        |m| m == netlink_packet_route::link::NetkitMode::L3,
+                    );
+                if is_l3 {
                     return Err(anyhow!(
-                        "netkit device {} has no MAC address (L3 mode not supported - use L2 mode or veth)",
+                        "netkit device {} is in L3 mode (not supported - use L2 mode or veth)",
                         attrs.name
                     ));
                 }

--- a/src/runtime-rs/crates/resource/src/network/network_with_netns.rs
+++ b/src/runtime-rs/crates/resource/src/network/network_with_netns.rs
@@ -24,7 +24,8 @@ use tokio::sync::RwLock;
 
 use super::{
     endpoint::{
-        Endpoint, IPVlanEndpoint, MacVlanEndpoint, PhysicalEndpoint, VethEndpoint, VlanEndpoint,
+        Endpoint, IPVlanEndpoint, MacVlanEndpoint, NetkitEndpoint, PhysicalEndpoint, VethEndpoint,
+        VlanEndpoint,
     },
     network_entity::NetworkEntity,
     network_info::network_info_from_link::{handle_addresses, NetworkInfoFromLink},
@@ -276,6 +277,26 @@ async fn create_endpoint(
                 )
                 .await
                 .context("macvlan endpoint")?;
+                Arc::new(ret)
+            }
+            "netkit" => {
+                // L3 mode netkit devices have no MAC address and are not supported.
+                if attrs.hardware_addr.is_empty() {
+                    return Err(anyhow!(
+                        "netkit device {} has no MAC address (L3 mode not supported - use L2 mode or veth)",
+                        attrs.name
+                    ));
+                }
+                let ret = NetkitEndpoint::new(
+                    &d,
+                    handle,
+                    &attrs.name,
+                    idx,
+                    &config.network_model,
+                    config.queues,
+                )
+                .await
+                .context("netkit endpoint")?;
                 Arc::new(ret)
             }
             _ => return Err(anyhow!("unsupported link type: {}", link_type)),

--- a/src/runtime-rs/crates/resource/src/network/utils/link/manager.rs
+++ b/src/runtime-rs/crates/resource/src/network/utils/link/manager.rs
@@ -5,7 +5,7 @@
 //
 
 use netlink_packet_route::link::{
-    InfoBridge, InfoData, InfoKind, LinkAttribute, LinkInfo, LinkMessage,
+    InfoBridge, InfoData, InfoKind, InfoNetkit, LinkAttribute, LinkInfo, LinkMessage, NetkitMode,
 };
 
 use super::{Link, LinkAttrs};
@@ -150,8 +150,8 @@ fn link_info(mut infos: Vec<LinkInfo>) -> Box<dyn Link> {
                 InfoData::Bridge(ibs) => {
                     link = Some(Box::new(parse_bridge(ibs)));
                 }
-                InfoData::Netkit(_) => {
-                    link = Some(Box::new(Netkit::default()));
+                InfoData::Netkit(nks) => {
+                    link = Some(Box::new(parse_netkit(nks)));
                 }
                 _ => {
                     link = Some(Box::new(Device::default()));
@@ -171,6 +171,17 @@ fn link_info(mut infos: Vec<LinkInfo>) -> Box<dyn Link> {
         }
     }
     link.unwrap()
+}
+
+fn parse_netkit(infos: Vec<InfoNetkit>) -> Netkit {
+    let mut netkit = Netkit::default();
+    for info in infos {
+        if let InfoNetkit::Mode(mode) = info {
+            netkit.mode = Some(mode);
+            break;
+        }
+    }
+    netkit
 }
 
 fn parse_bridge(mut ibs: Vec<InfoBridge>) -> Bridge {
@@ -204,6 +215,9 @@ macro_rules! impl_network_dev {
             fn r#type(&self) -> &'static str {
                 $r_type
             }
+            fn as_any(&self) -> &dyn std::any::Any {
+                self
+            }
         }
     };
 }
@@ -222,7 +236,13 @@ macro_rules! define_and_impl_network_dev {
 define_and_impl_network_dev!("device", Device);
 define_and_impl_network_dev!("tuntap", Tuntap);
 define_and_impl_network_dev!("veth", Veth);
-define_and_impl_network_dev!("netkit", Netkit);
+#[derive(Debug, PartialEq, Eq, Clone, Default)]
+pub struct Netkit {
+    attrs: Option<LinkAttrs>,
+    pub mode: Option<NetkitMode>,
+}
+
+impl_network_dev!("netkit", Netkit);
 define_and_impl_network_dev!("ipvlan", IpVlan);
 define_and_impl_network_dev!("macvlan", MacVlan);
 define_and_impl_network_dev!("vlan", Vlan);

--- a/src/runtime-rs/crates/resource/src/network/utils/link/manager.rs
+++ b/src/runtime-rs/crates/resource/src/network/utils/link/manager.rs
@@ -120,6 +120,11 @@ fn link_info(mut infos: Vec<LinkInfo>) -> Box<dyn Link> {
                         link = Some(Box::new(Bridge::default()));
                     }
                 }
+                InfoKind::Netkit => {
+                    if link.is_none() {
+                        link = Some(Box::new(Netkit::default()));
+                    }
+                }
                 _ => {
                     if link.is_none() {
                         link = Some(Box::new(Device::default()));
@@ -144,6 +149,9 @@ fn link_info(mut infos: Vec<LinkInfo>) -> Box<dyn Link> {
                 }
                 InfoData::Bridge(ibs) => {
                     link = Some(Box::new(parse_bridge(ibs)));
+                }
+                InfoData::Netkit(_) => {
+                    link = Some(Box::new(Netkit::default()));
                 }
                 _ => {
                     link = Some(Box::new(Device::default()));
@@ -214,6 +222,7 @@ macro_rules! define_and_impl_network_dev {
 define_and_impl_network_dev!("device", Device);
 define_and_impl_network_dev!("tuntap", Tuntap);
 define_and_impl_network_dev!("veth", Veth);
+define_and_impl_network_dev!("netkit", Netkit);
 define_and_impl_network_dev!("ipvlan", IpVlan);
 define_and_impl_network_dev!("macvlan", MacVlan);
 define_and_impl_network_dev!("vlan", Vlan);

--- a/src/runtime-rs/crates/resource/src/network/utils/link/mod.rs
+++ b/src/runtime-rs/crates/resource/src/network/utils/link/mod.rs
@@ -10,7 +10,7 @@ mod driver_info;
 pub use driver_info::get_driver_info;
 mod macros;
 mod manager;
-pub use manager::get_link_from_message;
+pub use manager::{get_link_from_message, Netkit};
 
 use std::os::unix::io::RawFd;
 
@@ -145,4 +145,5 @@ pub trait Link: Send + Sync {
     fn attrs(&self) -> &LinkAttrs;
     fn set_attrs(&mut self, attr: LinkAttrs);
     fn r#type(&self) -> &str;
+    fn as_any(&self) -> &dyn std::any::Any;
 }


### PR DESCRIPTION
## Summary

Port the Go runtime's netkit endpoint to the Rust shim. Adds `NetkitEndpoint` modeled after `VethEndpoint` with L3-mode detection.

Go counterpart commits:
- e3cd1c5d739612031105f530de62dce12d31dc03 — runtime: Add support for netkit endpoints
- 4ebe9dec45d5c3a02596c189a6f0b40f18245934 — runtime: Reject netkit L3 devices with clear error

## Test plan

Using pod:

```yaml
apiVersion: v1
kind: Pod
metadata:
  name: kata-val-b2
  namespace: default
spec:
  nodeName: us3-staging-dog-arbok-90eec5c94014646d000003
  runtimeClassName: kata-qemu-runtime-rs
  containers:
  - name: test
    image: registry.ddbuild.io/images/base/gbi-ubuntu_2204:release
    command: ["sleep", "3600"]
```

### Test B1 - Netkit mode L2

Expected: pod reaches Running, kata shim logs `netkit network interface found: eth0`

```yaml
apiVersion: cilium.io/v2
kind: CiliumNodeConfig
metadata:
  name: microvm-rust-shim-test
  namespace: cluster-cni
spec:
  defaults:
    bpf-lb-sock-hostns-only: "true"
    datapath-mode: netkit-l2
    enable-bpf-clock-probe: "true"
  nodeSelector:
    matchLabels:
      kubernetes.io/hostname: "us3-staging-dog-arbok-90eec5c94014646d000003"
```

Pass signals:
- Pod reaches Running
- Containerd logs:
```bash
root@us3-staging-dog-arbok-90eec5c94014646d000003:/home/ddeng# journalctl -u containerd --since "5m ago" | grep "netkit network interface found"
Apr 14 07:52:34 us3-staging-dog-arbok-90eec5c94014646d000003 kata[1366463]: netkit network interface found: eth0
```

### Test B2 - Veth mode

Expected: pod reaches Running, kata shim logs `veth network interface found: eth0`

```yaml
apiVersion: cilium.io/v2
kind: CiliumNodeConfig
metadata:
  name: microvm-rust-shim-test
  namespace: cluster-cni
spec:
  defaults:
    ...
    datapath-mode: veth
  nodeSelector:
    matchLabels:
      kubernetes.io/hostname: "us3-staging-dog-arbok-90eec5c94014646d000003"
```

Pass signals:
- Pod reaches Running - netkit endpoint created without errors
- Containerd logs:
```bash
root@us3-staging-dog-arbok-90eec5c94014646d000003:/home/ddeng# journalctl -u containerd --since "5m ago" | grep "veth network interface found"
Apr 14 08:00:00 us3-staging-dog-arbok-90eec5c94014646d000003 kata[1371086]: veth network interface found: eth0
```

### Test B3 - Netkit L3

Expected: pod reaches Running, kata shim logs `veth network interface found: eth0`

```yaml
apiVersion: cilium.io/v2
kind: CiliumNodeConfig
metadata:
  name: microvm-rust-shim-test
  namespace: cluster-cni
spec:
  defaults:
    ...
    datapath-mode: netkit # L3 mode
  nodeSelector:
    matchLabels:
      kubernetes.io/hostname: "us3-staging-dog-arbok-90eec5c94014646d000003"
```

Pass signals:
- Pod fails
```
 Warning  FailedCreatePodSandBox  4s    kubelet  Failed to create pod sandbox: rpc error: code = Unknown desc = failed to start sandbox "7828b01c8509949ed544c8b8f22b469fba74d32d801d51ec9ff0f8fa9966f14e": failed to create containerd task: failed to create shim task: Others("failed to handle message start sandbox in task handler

Caused by:
    0: set up device before start vm
    1: failed to handle network
    2: failed to set up network
    3: new network
    4: new network with netns
    5: get entity from netns
    6: create endpoint
    7: netkit device eth0 is in L3 mode (not supported - use L2 mode or veth)") 
```