### PR TITLE
runtime-rs: use CPU shares as vCPU fallback when CFS quota unset

### DIFF
--- a/src/libs/kata-types/src/annotations/mod.rs
+++ b/src/libs/kata-types/src/annotations/mod.rs
@@ -17,8 +17,9 @@ use crate::config::TomlConfig;
 use crate::initdata::add_hypervisor_initdata_overrides;
 use crate::sl;
 
-use self::cri_containerd::{SANDBOX_CPU_PERIOD_KEY, SANDBOX_CPU_QUOTA_KEY, SANDBOX_MEM_KEY};
-
+use self::cri_containerd::{
+    SANDBOX_CPU_PERIOD_KEY, SANDBOX_CPU_QUOTA_KEY, SANDBOX_CPU_SHARE_KEY, SANDBOX_MEM_KEY,
+};
 /// CRI-containerd specific annotations.
 pub mod cri_containerd;
 
@@ -451,6 +452,14 @@ impl Annotation {
     pub fn get_sandbox_cpu_period(&self) -> u64 {
         let value = self
             .get_value::<u64>(SANDBOX_CPU_PERIOD_KEY)
+            .unwrap_or(Some(0));
+        value.unwrap_or(0)
+    }
+
+    /// Get the annotation of CPU shares for sandbox
+    pub fn get_sandbox_cpu_shares(&self) -> u64 {
+        let value = self
+            .get_value::<u64>(SANDBOX_CPU_SHARE_KEY)
             .unwrap_or(Some(0));
         value.unwrap_or(0)
     }

--- a/src/runtime-rs/crates/resource/src/cpu_mem/cpu.rs
+++ b/src/runtime-rs/crates/resource/src/cpu_mem/cpu.rs
@@ -168,6 +168,23 @@ impl CpuResource {
             return Ok(cpuset_vcpu.len() as f32);
         }
 
+        // Fallback to CPU shares when quota and cpuset are both absent.
+        // This handles pods with no resource limits but with CPU shares set.
+        if total_quota == 0.0 && cpuset_vcpu.is_empty() {
+            let total_shares: u64 = resources
+                .values()
+                .map(|cpu_resource| cpu_resource.shares())
+                .sum();
+            if total_shares > 0 {
+                let shares_vcpu = total_shares as f32 / 1024.0;
+                info!(
+                    sl!(),
+                    "(from cpu_shares) get vcpus # {}", shares_vcpu
+                );
+                return Ok(shares_vcpu.max(1.0));
+            }
+        }
+
         // When quota is set: calculate vCPUs as quota/period after normalization
         if total_quota > 0.0 && max_period > 0.0 {
             let quota_vcpu = total_quota / max_period;

--- a/src/runtime-rs/crates/resource/src/cpu_mem/initial_size.rs
+++ b/src/runtime-rs/crates/resource/src/cpu_mem/initial_size.rs
@@ -42,6 +42,15 @@ impl TryFrom<&HashMap<String, String>> for InitialSize {
         if let Ok(cpu_resource) = LinuxContainerCpuResources::try_from(&cpu) {
             vcpu = get_nr_vcpu(&cpu_resource);
         }
+
+        // When neither quota/period nor cpuset constrain CPU, fall back to CPU shares annotation
+        let shares = annotation.get_sandbox_cpu_shares();
+        if vcpu == 0.0 {
+            if shares > 0 {
+                vcpu = shares as f32 / 1024.0;
+            }
+        }
+
         let mem_mb = convert_memory_to_mb(memory);
 
         Ok(Self {
@@ -265,6 +274,71 @@ mod tests {
             },
         ]
         .to_vec()
+    }
+
+    // Test that sandbox CPU-shares annotation is used as vcpu fallback when
+    // quota and period are absent.
+    #[test]
+    fn test_initial_size_sandbox_cpu_shares_fallback() {
+        let cases: &[(&str, u64, f32)] = &[
+            ("1024 shares = 1.0 vcpu", 1024, 1.0),
+            ("2048 shares = 2.0 vcpu", 2048, 2.0),
+            ("512 shares = 0.5 vcpu", 512, 0.5),
+            ("0 shares = 0.0 vcpu (no fallback)", 0, 0.0),
+        ];
+
+        for (desc, shares, expected_vcpu) in cases {
+            let annotations = HashMap::from([
+                (
+                    cri_containerd::CONTAINER_TYPE_LABEL_KEY.to_string(),
+                    cri_containerd::SANDBOX.to_string(),
+                ),
+                (
+                    cri_containerd::SANDBOX_CPU_SHARE_KEY.to_string(),
+                    format!("{}", shares),
+                ),
+            ]);
+
+            let initial_size = InitialSize::try_from(&annotations).unwrap();
+            assert_eq!(
+                initial_size.vcpu, *expected_vcpu,
+                "{}: got vcpu={}, expected {}",
+                desc, initial_size.vcpu, expected_vcpu
+            );
+        }
+    }
+
+    // Verify quota/period take precedence over shares when both are present.
+    #[test]
+    fn test_initial_size_sandbox_quota_wins_over_shares() {
+        let annotations = HashMap::from([
+            (
+                cri_containerd::CONTAINER_TYPE_LABEL_KEY.to_string(),
+                cri_containerd::SANDBOX.to_string(),
+            ),
+            (
+                cri_containerd::SANDBOX_CPU_PERIOD_KEY.to_string(),
+                "100000".to_string(),
+            ),
+            (
+                cri_containerd::SANDBOX_CPU_QUOTA_KEY.to_string(),
+                "220000".to_string(),
+            ),
+            // shares set too - quota should win
+            (
+                cri_containerd::SANDBOX_CPU_SHARE_KEY.to_string(),
+                "4096".to_string(), // would be 4.0 if shares were used
+            ),
+        ]);
+
+        let initial_size = InitialSize::try_from(&annotations).unwrap();
+        // 220_000/100_000 = 2.2 -> ceil = 3.0, not 4.0 from shares
+        assert_eq!(
+            initial_size.vcpu.ceil(),
+            3.0,
+            "quota should take precedence over shares, got vcpu={}",
+            initial_size.vcpu
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

When sandbox-cpu-quota/period annotations are zero (CFS disabled or no limits set), fall back to `sandbox-cpu-shares / 1024` to size the microVM vCPUs, mirroring Go's `CalculateCPUsF(quota, period, shares)`.

Go counterpart commit:
- 14e6412075daa21df45af1f273b0697db3df33fd - Take CPU shares into account when computing the sandbox size

## Test plan

### Test A1 - CPU shares fallback (shares → 2 vCPU)

```yaml
apiVersion: v1
kind: Pod
metadata:
  name: kata-val-a2
  namespace: default
spec:
  nodeName: us3-staging-dog-arbok-90eec5c94014646d000003
  runtimeClassName: kata-qemu-runtime-rs
  containers:
  - name: test
    image: registry.ddbuild.io/images/base/gbi-ubuntu_2204:release
    command: ["sleep", "3600"]
    resources:
      requests:
        cpu: "2"
```

Pass signals:
- Pod reaches Running
- `nproc = 2` instead of fallback 1

```bash
journalctl -u containerd --since "2 minutes ago" | grep -i "vcpu\|cpu_shares\|initial size"
# Expected: kata[...]: resource with vcpu 2
```

### Test A2 - CPU shares fallback (with limits set)

```yaml
apiVersion: v1
kind: Pod
metadata:
  name: kata-val-a2
  namespace: default
spec:
  nodeName: us3-staging-dog-arbok-90eec5c94014646d000003
  runtimeClassName: kata-qemu-runtime-rs
  containers:
  - name: test
    image: registry.ddbuild.io/images/base/gbi-ubuntu_2204:release
    command: ["sleep", "3600"]
    resources:
      requests:
        cpu: "2"
      limits:
        cpu: "4"
```

Pass signals:
- Pod reaches Running
- `nproc = 2`