### PR TITLE
[codex] Disable IPv4 ESP in Kata guest kernel config

### DIFF
--- a/tools/packaging/kernel/configs/fragments/common/network.conf
+++ b/tools/packaging/kernel/configs/fragments/common/network.conf
@@ -80,7 +80,9 @@ CONFIG_MACVLAN=y
 CONFIG_MACVTAP=y
 CONFIG_BRIDGE_NETFILTER=y
 CONFIG_VXLAN=y
-CONFIG_INET_ESP=y
+# IPsec ESP is not required by default Kata workloads. Keep it disabled to
+# remove the DirtyFrag ESP page-cache write trigger from unprivileged guests.
+# CONFIG_INET_ESP is not set
 
 
 # Need netfilter support for iptables


### PR DESCRIPTION
## Summary

Disable `CONFIG_INET_ESP` in the common Kata guest kernel network fragment.

## Why

The Kata guest kernel currently enables IPv4 IPsec ESP by default. DirtyFrag uses the ESP receive path as the page-cache write primitive, and the sandboxes workload model does not require guests to run their own IPsec ESP stack by default.

Disabling IPv4 ESP removes that trigger while preserving normal networking, TLS/mTLS, SSH, DNS, HTTP egress, netfilter, VXLAN, TUN/TAP, OpenVPN-over-TUN, and WireGuard.

## Impact

Guest workloads that create IPv4 IPsec ESP SAs inside the Kata VM will no longer work with the default kernel config. Other networking paths are unaffected.

## Validation

- Confirmed the fragment no longer contains `CONFIG_INET_ESP=y`.
- Confirmed it now contains `# CONFIG_INET_ESP is not set`.