### PR TITLE
kernel: drop unused CONFIG_INET_ESP from default config

### DIFF
--- a/tools/packaging/kernel/configs/fragments/common/network.conf
+++ b/tools/packaging/kernel/configs/fragments/common/network.conf
@@ -82,7 +82,8 @@ CONFIG_MACVLAN=y
 CONFIG_MACVTAP=y
 CONFIG_BRIDGE_NETFILTER=y
 CONFIG_VXLAN=y
-CONFIG_INET_ESP=y
+# IPsec ESP is not required by default Kata workloads. Keep it disabled.
+# CONFIG_INET_ESP is not set
 
 
 # Need netfilter support for iptables


### PR DESCRIPTION
Disable `CONFIG_INET_ESP` (IPsec ESP) in the common kernel network                                                                                                                       config fragment. The Kata workloads we run do not use                                                                                                                         IPsec, so this code path was unused. Removing it trims the kernel                                                                                                                        config to what we actually need.

## Test plan                                                                                                                                                                               
                                                                                                                                                                                             
  - Built a custom kernel + AMI carrying this config change.                                                                                                                                 
  - Deployed to a single staging cluster and ran our usual sandbox
    workloads against it without regression.