### PR TITLE
mj [upstream-chaser] Conflict: 0005-datadog-shim-sandbox-size-based-on-cpu-shares.patch on 3.32.0-mj

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,0 +1,9 @@
+upstream:  https://github.com/kata-containers/kata-containers
+repo:  https://github.com/DataDog/kata-containers
+patchFolders:
+  - patches/global
+tagLimit: 3
+tagMatchers:
+  - "3.*.*"
+branchTemplate: "{{ .Tag }}-mj"
+conflictPR: true

--- a/patches/global/0001-datadog-ci-gitlab-and-gha.patch
+++ b/patches/global/0001-datadog-ci-gitlab-and-gha.patch
@@ -1,0 +1,310 @@
+From 2d1b033d27d1cfe5abb84cabe4413c25eff8309b Mon Sep 17 00:00:00 2001
+From: Mateo Lelong <mateo.lelong@datadoghq.com>
+Date: Fri, 22 May 2026 10:58:17 +0200
+Subject: [PATCH] [datadog] ci: gitlab and gha
+
+---
+ .github/workflows/build-kata-os.yml | 101 ++++++++++++++++++++
+ .gitlab-ci.yml                      | 141 ++++++++++++++++++++++++++++
+ tools/packaging/kernel/Dockerfile   |  33 +++++++
+ 3 files changed, 275 insertions(+)
+ create mode 100644 .github/workflows/build-kata-os.yml
+ create mode 100644 .gitlab-ci.yml
+ create mode 100644 tools/packaging/kernel/Dockerfile
+
+diff --git a/.github/workflows/build-kata-os.yml b/.github/workflows/build-kata-os.yml
+new file mode 100644
+index 000000000..e0f465a6e
+--- /dev/null
++++ b/.github/workflows/build-kata-os.yml
+@@ -0,0 +1,101 @@
++name: Build Kata OS
++run-name: Build Kata OS
++on: [push]
++permissions:
++  contents: write
++jobs:
++  build:
++    strategy:
++      matrix:
++        runner: [ubuntu-22.04, arm-8core-linux]
++        include:
++          - runner: ubuntu-22.04
++            arch: amd64
++            kernel_version: 6.8
++            musl_arch: x86_64
++          - runner: arm-8core-linux
++            arch: arm64
++            kernel_version: 6.8
++            musl_arch: aarch64
++    runs-on: ${{ matrix.runner }}
++    steps:
++      - name: Check out repository code
++        uses: actions/checkout@v4
++      - uses: actions/setup-go@v5
++        with:
++          go-version: ">=1.24.0"
++      - name: Install rust
++        run: ./tests/install_rust.sh
++      - name: Install dependencies
++        run: sudo apt-get update && sudo apt-get install -y libelf-dev flex bison libssl-dev pahole g++ cmake musl-tools
++
++      - name: Build containerd-shim-kata-v2
++        run: |
++          cd src/runtime
++          make -j$(nproc) containerd-shim-v2
++      - name: Build containerd-shim-kata-v2-rs
++        env:
++          CC_${{ matrix.musl_arch }}-unknown-linux-musl: musl-gcc
++          CARGO_TARGET_${{ matrix.musl_arch }}_UNKNOWN_LINUX_MUSL_LINKER: musl-gcc
++        run: |
++          rustup target add ${{ matrix.musl_arch }}-unknown-linux-musl
++          cd src/runtime-rs
++          make clean-generated-files
++          make PREFIX=/opt/kata
++          cp ../../target/${{ matrix.musl_arch }}-unknown-linux-musl/release/containerd-shim-kata-v2 /tmp/containerd-shim-kata-v2-rs
++      - name: Build Ubuntu image ${{ matrix.arch }}
++        run: cd tools/osbuilder && sudo make USE_DOCKER=true OS_VERSION=jammy image-ubuntu
++      - name: Build Kernel ${{ matrix.kernel_version }}
++        run: |
++          cd tools/packaging/kernel
++          sudo KERNEL_DEBUG_ENABLED=yes ./build-kernel.sh -v ${{ matrix.kernel_version }} setup
++          sudo ./build-kernel.sh -v ${{ matrix.kernel_version }} build
++      - name: Bundle artifacts
++        run: |
++          if [[ "${{ matrix.arch }}" == "amd64" ]]
++          then
++            cp tools/packaging/kernel/kata-linux-*/arch/x86/boot/bzImage /tmp/vmlinux
++          else
++            cp tools/packaging/kernel/kata-linux-*/arch/arm64/boot/Image.gz /tmp/vmlinux
++          fi
++          cp tools/osbuilder/kata-containers-image-ubuntu.img /tmp/kata-containers-image-ubuntu.img
++          cp sbom.cdx.gz /tmp/sbom.cdx.gz
++          cp src/runtime/containerd-shim-kata-v2 /tmp/containerd-shim-kata-v2
++          mkdir -p /tmp/artifacts
++          zip -j /tmp/artifacts/artifacts-${{ matrix.arch }}.zip /tmp/vmlinux /tmp/kata-containers-image-ubuntu.img /tmp/sbom.cdx.gz /tmp/containerd-shim-kata-v2 /tmp/containerd-shim-kata-v2-rs
++          cd /tmp/artifacts
++          sha256sum artifacts-${{ matrix.arch }}.zip > checksum-${{ matrix.arch }}.sha256
++      - name: Upload Artifact
++        uses: actions/upload-artifact@v4
++        with:
++          name: artifacts-${{ matrix.arch }}
++          path: /tmp/artifacts
++          retention-days: 1
++  release:
++    runs-on: ubuntu-22.04
++    needs: build
++    # Only create a release when a new tag is created
++    if: ${{ startsWith(github.ref, 'refs/tags/') }}
++    steps:
++      - name: Check out repository code
++        uses: actions/checkout@v4
++      - name: Download artifacts amd64
++        uses: actions/download-artifact@v4
++        with:
++          name: artifacts-amd64
++      - name: Download artifacts arm64
++        uses: actions/download-artifact@v4
++        with:
++          name: artifacts-arm64
++      - name: "Create New Release"
++        env:
++          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
++        run: |
++          RELEASE_VERSION=$(echo ${{ github.ref }} | sed 's/refs\/tags\///')
++          echo "Creating release $RELEASE_VERSION"
++          gh release create ${RELEASE_VERSION} -t ${RELEASE_VERSION} --draft
++          gh release upload "${RELEASE_VERSION}" artifacts-amd64.zip
++          gh release upload "${RELEASE_VERSION}" artifacts-arm64.zip
++          gh release upload "${RELEASE_VERSION}" checksum-amd64.sha256
++          gh release upload "${RELEASE_VERSION}" checksum-arm64.sha256
++          gh release edit ${RELEASE_VERSION} --verify-tag	--draft=false
+diff --git a/.gitlab-ci.yml b/.gitlab-ci.yml
+new file mode 100644
+index 000000000..68513f146
+--- /dev/null
++++ b/.gitlab-ci.yml
+@@ -0,0 +1,141 @@
++include: https://gitlab-templates.ddbuild.io/compute-delivery/v3/compute-delivery.yml
++
++variables:
++  CI_IMAGE: 3
++  KERNEL_VERSION: 6.8
++  KUBERNETES_CPU_REQUEST: "10"
++  KUBERNETES_MEMORY_REQUEST: "20Gi"
++  KUBERNETES_MEMORY_LIMIT: "40Gi"
++  KERNEL_DEBUG_ENABLED: "yes"
++
++stages:
++  - ci-image
++  - build
++  - publish
++  - notify
++
++ci-image:
++  stage: ci-image
++  extends: .build-docker-image
++  when: manual
++  only:
++    - branches
++  variables:
++    IMAGE_NAME: "$CI_PROJECT_NAME/ci"
++    IMAGE_TAG: $CI_IMAGE
++    CONTEXT_DIR: "./tools/packaging/kernel"
++    TARGET: "build"
++
++build-kernel-amd64:
++  image: registry.ddbuild.io/$CI_PROJECT_NAME/ci:$CI_IMAGE
++  stage: build
++  tags: [ "arch:amd64" ]
++  script:
++    - cd tools/packaging/kernel
++    - ./build-kernel.sh -v $KERNEL_VERSION setup
++    - ./build-kernel.sh -v $KERNEL_VERSION build
++    - cp kata-linux-*/arch/x86_64/boot/bzImage ./vmlinux-amd64
++  artifacts:
++    paths:
++      - tools/packaging/kernel/vmlinux-amd64
++    expire_in: 1 week
++
++build-kernel-arm64:
++  image: registry.ddbuild.io/$CI_PROJECT_NAME/ci:$CI_IMAGE
++  stage: build
++  tags: [ "arch:arm64" ]
++  script:
++    - cd tools/packaging/kernel
++    - ./build-kernel.sh -v $KERNEL_VERSION setup
++    - ./build-kernel.sh -v $KERNEL_VERSION build
++    - cp kata-linux-*/arch/arm64/boot/Image.gz ./vmlinux-arm64
++  artifacts:
++    paths:
++      - tools/packaging/kernel/vmlinux-arm64
++    expire_in: 1 week
++
++build-shim-amd64:
++  image: registry.ddbuild.io/images/mirror/library/golang:1.24.5
++  stage: build
++  tags: [ "arch:amd64" ]
++  variables:
++    GOTOOLCHAIN: auto
++  script:
++    - cd src/runtime
++    - make containerd-shim-v2
++    - mv containerd-shim-kata-v2 containerd-shim-kata-v2-amd64
++  artifacts:
++    paths:
++      - src/runtime/containerd-shim-kata-v2-amd64
++    expire_in: 1 week
++
++build-shim-arm64:
++  image: registry.ddbuild.io/images/mirror/library/golang:1.24.5
++  stage: build
++  tags: [ "arch:arm64" ]
++  variables:
++    GOTOOLCHAIN: auto
++  script:
++    - cd src/runtime
++    - make containerd-shim-v2
++    - mv containerd-shim-kata-v2 containerd-shim-kata-v2-arm64
++  artifacts:
++    paths:
++      - src/runtime/containerd-shim-kata-v2-arm64
++    expire_in: 1 week
++
++build-shim-rust-amd64:
++  image: registry.ddbuild.io/images/mirror/rust:1.91
++  stage: build
++  tags: [ "arch:amd64" ]
++  script:
++    - apt-get update -q && apt-get install -yq musl-tools g++ cmake
++    - INSTALL_IN_GOPATH=false ci/install_yq.sh
++    - tests/install_rust.sh
++    - cd src/runtime-rs
++    - make clean-generated-files
++    - make check
++    - make PREFIX=/opt/kata QEMUCMD=qemu-system-x86_64
++    - cp ../../target/x86_64-unknown-linux-musl/release/containerd-shim-kata-v2 containerd-shim-kata-v2-rust-amd64
++  artifacts:
++    paths:
++      - src/runtime-rs/containerd-shim-kata-v2-rust-amd64
++    expire_in: 1 week
++
++build-shim-rust-arm64:
++  image: registry.ddbuild.io/images/mirror/rust:1.91
++  stage: build
++  tags: [ "arch:arm64" ]
++  script:
++    - apt-get update -q && apt-get install -yq musl-tools g++ cmake
++    - INSTALL_IN_GOPATH=false ci/install_yq.sh
++    - tests/install_rust.sh
++    - cd src/runtime-rs
++    - make clean-generated-files
++    - make check
++    - ARCH=aarch64 make PREFIX=/opt/kata QEMUCMD=qemu-system-aarch64
++    - cp ../../target/aarch64-unknown-linux-musl/release/containerd-shim-kata-v2 containerd-shim-kata-v2-rust-arm64
++  artifacts:
++    paths:
++      - src/runtime-rs/containerd-shim-kata-v2-rust-arm64
++    expire_in: 1 week
++
++publish-artifacts:
++  image: registry.ddbuild.io/$CI_PROJECT_NAME/ci:$CI_IMAGE
++  stage: publish
++  only:
++    - tags
++  tags: [ "arch:amd64" ]
++  dependencies:
++    - "build-kernel-amd64"
++    - "build-kernel-arm64"
++    - "build-shim-rust-amd64"
++    - "build-shim-rust-arm64"
++  variables:
++    GIT_STRATEGY: none
++  script:
++    - aws s3 cp tools/packaging/kernel/vmlinux-amd64 s3://kata-containers-ci-artifacts/$CI_COMMIT_REF_NAME/amd64/vmlinux
++    - aws s3 cp tools/packaging/kernel/vmlinux-arm64 s3://kata-containers-ci-artifacts/$CI_COMMIT_REF_NAME/arm64/vmlinux
++    - aws s3 cp src/runtime-rs/containerd-shim-kata-v2-rust-amd64 s3://kata-containers-ci-artifacts/$CI_COMMIT_REF_NAME/amd64/containerd-shim-kata-v2
++    - aws s3 cp src/runtime-rs/containerd-shim-kata-v2-rust-arm64 s3://kata-containers-ci-artifacts/$CI_COMMIT_REF_NAME/arm64/containerd-shim-kata-v2
++    - echo $CI_COMMIT_REF_NAME > LATEST && aws s3 cp LATEST s3://kata-containers-ci-artifacts/LATEST
+diff --git a/tools/packaging/kernel/Dockerfile b/tools/packaging/kernel/Dockerfile
+new file mode 100644
+index 000000000..b841ac633
+--- /dev/null
++++ b/tools/packaging/kernel/Dockerfile
+@@ -0,0 +1,33 @@
++FROM registry.ddbuild.io/images/base/gbi-ubuntu_2204:release
++
++ARG GOLANG_VERSION=1.22.2
++ARG TARGETARCH
++
++USER root
++
++# Install the required packages
++RUN apt-get update && apt-get install -y \
++    flex \
++    bison \
++    libelf-dev \
++    libssl-dev \
++    pahole \
++    xz-utils \
++    gcc \
++    make \
++    patch \
++    bc \
++    python3-pip
++
++# Install golang
++RUN curl -fs https://dl.google.com/go/go$GOLANG_VERSION.linux-${TARGETARCH}.tar.gz | tar -v -C /usr/local -xz
++ENV GOPATH /go
++ENV PATH $GOPATH/bin:/usr/local/go/bin:$PATH
++
++# Install yq
++
++RUN go install github.com/mikefarah/yq/v4@latest
++
++# Install AWS CLI
++
++RUN pip3 install awscli
+-- 
+2.54.0
+

--- a/patches/global/0002-datadog-chore-no_patch-6.8.x.patch
+++ b/patches/global/0002-datadog-chore-no_patch-6.8.x.patch
@@ -1,0 +1,16 @@
+From 791ab9064cb79037bf7f9e48ae18f32ef5d1c9d2 Mon Sep 17 00:00:00 2001
+From: Mateo Lelong <mateo.lelong@datadoghq.com>
+Date: Fri, 22 May 2026 11:05:15 +0200
+Subject: [PATCH] [datadog] chore: no_patch 6.8.x
+
+---
+ tools/packaging/kernel/patches/6.8.x/no_patches.txt | 0
+ 1 file changed, 0 insertions(+), 0 deletions(-)
+ create mode 100644 tools/packaging/kernel/patches/6.8.x/no_patches.txt
+
+diff --git a/tools/packaging/kernel/patches/6.8.x/no_patches.txt b/tools/packaging/kernel/patches/6.8.x/no_patches.txt
+new file mode 100644
+index 000000000..e69de29bb
+-- 
+2.54.0
+

--- a/patches/global/0003-datadog-osbuilder-system-config.patch
+++ b/patches/global/0003-datadog-osbuilder-system-config.patch
@@ -1,0 +1,98 @@
+From e9ccf17c334283f10583c9eff37c653c9cd7cf04 Mon Sep 17 00:00:00 2001
+From: Mateo Lelong <mateo.lelong@datadoghq.com>
+Date: Fri, 22 May 2026 11:12:15 +0200
+Subject: [PATCH] [datadog] osbuilder: system config
+
+---
+ .../etc/sysctl.d/99-datadog.conf              | 40 +++++++++++++++++++
+ .../etc/systemd/system.conf.d/10-rlimits.conf |  2 +
+ tools/osbuilder/rootfs-builder/rootfs.sh      | 10 +++++
+ 3 files changed, 52 insertions(+)
+ create mode 100644 tools/osbuilder/rootfs-builder/datadog-files/etc/sysctl.d/99-datadog.conf
+ create mode 100644 tools/osbuilder/rootfs-builder/datadog-files/etc/systemd/system.conf.d/10-rlimits.conf
+
+diff --git a/tools/osbuilder/rootfs-builder/datadog-files/etc/sysctl.d/99-datadog.conf b/tools/osbuilder/rootfs-builder/datadog-files/etc/sysctl.d/99-datadog.conf
+new file mode 100644
+index 000000000..66a0e84b2
+--- /dev/null
++++ b/tools/osbuilder/rootfs-builder/datadog-files/etc/sysctl.d/99-datadog.conf
+@@ -0,0 +1,40 @@
++fs.nr_open = 2097152
++fs.suid_dumpable = 0
++kernel.dmesg_restrict = 1
++kernel.hung_task_warnings = -1
++kernel.keys.maxkeys = 500
++kernel.perf_event_mlock_kb = 2064
++kernel.perf_event_paranoid = 2
++kernel.randomize_va_space = 2
++net.core.netdev_max_backlog = 40000
++net.core.rmem_max = 16777216
++net.core.somaxconn = 10240
++net.core.wmem_max = 16777216
++net.ipv4.conf.all.accept_redirects = 0
++net.ipv4.conf.all.accept_source_route = 0
++net.ipv4.conf.all.log_martians = 1
++net.ipv4.conf.all.route_localnet = 1
++net.ipv4.conf.all.rp_filter = 2
++net.ipv4.conf.all.secure_redirects = 0
++net.ipv4.conf.all.send_redirects = 0
++net.ipv4.conf.default.accept_redirects = 0
++net.ipv4.conf.default.accept_source_route = 0
++net.ipv4.conf.default.log_martians = 1
++net.ipv4.conf.default.rp_filter = 2
++net.ipv4.conf.default.secure_redirects = 0
++net.ipv4.conf.default.send_redirects = 0
++net.ipv4.icmp_echo_ignore_broadcasts = 1
++net.ipv4.icmp_ignore_bogus_error_responses = 1
++net.ipv4.ip_forward = 1
++net.ipv4.neigh.default.gc_thresh1 = 0
++net.ipv4.neigh.default.gc_thresh2 = 8192
++net.ipv4.neigh.default.gc_thresh3 = 16384
++net.ipv4.tcp_max_syn_backlog = 10240
++net.ipv4.tcp_max_tw_buckets = 2000000
++net.ipv4.tcp_retries2 = 7
++net.ipv4.tcp_rfc1337 = 1
++net.ipv4.tcp_rmem = 4096 65536 16777216
++net.ipv4.tcp_syn_retries = 2
++net.ipv4.tcp_syncookies = 1
++net.ipv4.tcp_wmem = 4096 65536 16777216
++vm.max_map_count = 2147483647
+diff --git a/tools/osbuilder/rootfs-builder/datadog-files/etc/systemd/system.conf.d/10-rlimits.conf b/tools/osbuilder/rootfs-builder/datadog-files/etc/systemd/system.conf.d/10-rlimits.conf
+new file mode 100644
+index 000000000..ea0917a81
+--- /dev/null
++++ b/tools/osbuilder/rootfs-builder/datadog-files/etc/systemd/system.conf.d/10-rlimits.conf
+@@ -0,0 +1,2 @@
++[Manager]
++DefaultLimitNPROC=131072
+diff --git a/tools/osbuilder/rootfs-builder/rootfs.sh b/tools/osbuilder/rootfs-builder/rootfs.sh
+index 6e07f1d3c..02eda4f87 100755
+--- a/tools/osbuilder/rootfs-builder/rootfs.sh
++++ b/tools/osbuilder/rootfs-builder/rootfs.sh
+@@ -913,6 +913,15 @@ delete_unnecessary_files()
+ 	done
+ }
+ 
++############### [DATADOG] ###############
++setup_rootfs_dd_specific()
++{
++	if [ -d "${script_dir}/datadog-files" ]; then
++		cp -a "${script_dir}/datadog-files/." "${ROOTFS_DIR}/"
++	fi
++}
++########################################
++
+ main()
+ {
+ 	parse_arguments "$@"
+@@ -931,6 +940,7 @@ main()
+ 
+ 	init="${ROOTFS_DIR}/sbin/init"
+ 	setup_rootfs
++	setup_rootfs_dd_specific
+ 
+ 	if [[ "${BUILD_VARIANT}" = "nvidia-gpu" ]]; then
+ 		setup_nvidia_gpu_rootfs_stage_one
+-- 
+2.54.0
+

--- a/patches/global/0004-datadog-chore-sbom-generation.patch
+++ b/patches/global/0004-datadog-chore-sbom-generation.patch
@@ -1,0 +1,124 @@
+From f92d3b0d0dd80082ed36e50e88dd766ea625be9d Mon Sep 17 00:00:00 2001
+From: Mateo Lelong <mateo.lelong@datadoghq.com>
+Date: Fri, 22 May 2026 11:17:02 +0200
+Subject: [PATCH] [datadog] chore: sbom generation
+
+---
+ .../osbuilder/hooks/download_generate_sbom.sh |  5 +++
+ .../rootfs-builder/ubuntu/Dockerfile.in       | 43 +++++++++++--------
+ .../rootfs-builder/ubuntu/rootfs_lib.sh       |  2 +
+ 3 files changed, 32 insertions(+), 18 deletions(-)
+ create mode 100755 tools/osbuilder/hooks/download_generate_sbom.sh
+
+diff --git a/tools/osbuilder/hooks/download_generate_sbom.sh b/tools/osbuilder/hooks/download_generate_sbom.sh
+new file mode 100755
+index 000000000..73d630cc0
+--- /dev/null
++++ b/tools/osbuilder/hooks/download_generate_sbom.sh
+@@ -0,0 +1,5 @@
++#!/bin/bash -eux
++
++trivy fs /rootfs -f cyclonedx -o /kata-containers/sbom.cdx 2>&1 | tee /kata-containers/trivy.log
++
++gzip /kata-containers/sbom.cdx
+diff --git a/tools/osbuilder/rootfs-builder/ubuntu/Dockerfile.in b/tools/osbuilder/rootfs-builder/ubuntu/Dockerfile.in
+index 0feafa7f7..54ff4d3d8 100644
+--- a/tools/osbuilder/rootfs-builder/ubuntu/Dockerfile.in
++++ b/tools/osbuilder/rootfs-builder/ubuntu/Dockerfile.in
+@@ -31,12 +31,12 @@ RUN apt-get update && \
+     curl \
+     g++ \
+     $(gcc_arch="@ARCH@" && [ "$(uname -m)" != "$gcc_arch" ] && ( \
+-         libc_arch="$gcc_arch" && \
+-         [ "$gcc_arch" = aarch64 ] && libc_arch=arm64; \
+-         [ "$gcc_arch" = ppc64le ] && gcc_arch=powerpc64le && libc_arch=ppc64el; \
+-         [ "$gcc_arch" = s390x ] && gcc_arch=s390x && libc_arch=s390x; \
+-         [ "$gcc_arch" = x86_64 ] && gcc_arch=x86-64 && libc_arch=amd64; \
+-         echo "gcc-$gcc_arch-linux-gnu libc6-dev-$libc_arch-cross")) \
++    libc_arch="$gcc_arch" && \
++    [ "$gcc_arch" = aarch64 ] && libc_arch=arm64; \
++    [ "$gcc_arch" = ppc64le ] && gcc_arch=powerpc64le && libc_arch=ppc64el; \
++    [ "$gcc_arch" = s390x ] && gcc_arch=s390x && libc_arch=s390x; \
++    [ "$gcc_arch" = x86_64 ] && gcc_arch=x86-64 && libc_arch=amd64; \
++    echo "gcc-$gcc_arch-linux-gnu libc6-dev-$libc_arch-cross")) \
+     git \
+     gnupg2 \
+     libclang-dev \
+@@ -52,19 +52,26 @@ RUN apt-get update && \
+     python3-dev \
+     libclang-dev \
+     file \
++    wget \
+     zstd && \
+     apt-get clean && rm -rf /var/lib/apt/lists/&& \
+     curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain ${RUST_TOOLCHAIN}
+ 
++RUN wget -qO - https://aquasecurity.github.io/trivy-repo/deb/public.key | gpg --dearmor | tee /usr/share/keyrings/trivy.gpg > /dev/null && \
++    echo "deb [signed-by=/usr/share/keyrings/trivy.gpg] https://aquasecurity.github.io/trivy-repo/deb generic main" | tee -a /etc/apt/sources.list.d/trivy.list && \
++    apt-get update && apt-get install -y --no-install-recommends trivy && \
++    apt-get clean && rm -rf /var/lib/apt/lists/
++
++
+ RUN ARCH=$(uname -m); \
+     goarch=""; \
+     kernelname=$(uname -s | tr '[:upper:]' '[:lower:]'); \
+     case "${ARCH}" in \
+-        "aarch64") goarch="arm64" ;; \
+-        "ppc64le") goarch=${ARCH} ;; \
+-        "x86_64") goarch="amd64" ;; \
+-        "s390x") goarch=${ARCH} ;; \
+-        *) echo "Unsupported architecture: ${ARCH}" && exit 1 ;; \
++    "aarch64") goarch="arm64" ;; \
++    "ppc64le") goarch=${ARCH} ;; \
++    "x86_64") goarch="amd64" ;; \
++    "s390x") goarch=${ARCH} ;; \
++    *) echo "Unsupported architecture: ${ARCH}" && exit 1 ;; \
+     esac; \
+     curl -fsSOL "https://go.dev/dl/go${GO_VERSION}.${kernelname}-${goarch}.tar.gz" && \
+     tar -C "${GO_HOME}" -xzf "go${GO_VERSION}.${kernelname}-${goarch}.tar.gz" && \
+@@ -74,15 +81,15 @@ RUN ARCH=$(uname -m); \
+ RUN if [ ! -f "/usr/bin/$(uname -m)-linux-musl-gcc" ]; then ln -s /usr/bin/musl-gcc "/usr/bin/$(uname -m)-linux-musl-gcc"; fi
+ 
+ RUN ARCH=$(uname -m); \
+-	rust_arch=""; \
++    rust_arch=""; \
+     libc=""; \
+     case "${ARCH}" in \
+-        "aarch64") rust_arch="${ARCH}"; libc="musl"; ;; \
+-        "ppc64le") rust_arch="powerpc64le"; libc="gnu"; ;; \
+-        "x86_64") rust_arch="${ARCH}"; libc="musl"; ;; \
+-        "s390x") rust_arch="${ARCH}"; libc="gnu"; ;; \
+-        *) echo "Unsupported architecture: ${ARCH}" && exit 1 ;; \
+-	esac; \
++    "aarch64") rust_arch="${ARCH}"; libc="musl"; ;; \
++    "ppc64le") rust_arch="powerpc64le"; libc="gnu"; ;; \
++    "x86_64") rust_arch="${ARCH}"; libc="musl"; ;; \
++    "s390x") rust_arch="${ARCH}"; libc="gnu"; ;; \
++    *) echo "Unsupported architecture: ${ARCH}" && exit 1 ;; \
++    esac; \
+     rustup target add "${rust_arch}-unknown-linux-${libc}"
+ 
+ RUN pip install --no-cache-dir pyinstaller==6.9.0 || pip install --no-cache-dir pyinstaller==6.9.0 --break-system-packages
+diff --git a/tools/osbuilder/rootfs-builder/ubuntu/rootfs_lib.sh b/tools/osbuilder/rootfs-builder/ubuntu/rootfs_lib.sh
+index 5d1e51feb..e8d29688f 100644
+--- a/tools/osbuilder/rootfs-builder/ubuntu/rootfs_lib.sh
++++ b/tools/osbuilder/rootfs-builder/ubuntu/rootfs_lib.sh
+@@ -10,6 +10,7 @@ build_rootfs() {
+ 	# This fixes the spurious error
+ 	# E: Can't find a source to download version '2021.03.26' of 'ubuntu-keyring:amd64'
+ 	apt update
++
+ 	# focal version of mmdebstrap only supports comma separated package lists
+ 	# shellcheck disable=SC2154
+ 	if [[ "${OS_VERSION}" = "focal" ]]; then
+@@ -19,6 +20,7 @@ build_rootfs() {
+ 	# shellcheck disable=SC2154
+ 	if ! mmdebstrap --mode auto --arch "${DEB_ARCH}" --variant required \
+ 			--components="${REPO_COMPONENTS}" \
++			--customize-hook "/kata-containers/tools/osbuilder/hooks/download_generate_sbom.sh" \
+ 			--include "${PACKAGES},${EXTRA_PKGS}" "${OS_VERSION}" "${rootfs_dir}" "${REPO_URL}"; then
+ 		echo "ERROR: mmdebstrap failed, cannot proceed" && exit 1
+ 	else
+-- 
+2.54.0
+

--- a/patches/global/0005-datadog-shim-sandbox-size-based-on-cpu-shares.patch
+++ b/patches/global/0005-datadog-shim-sandbox-size-based-on-cpu-shares.patch
@@ -1,0 +1,340 @@
+From b132a08ea1fce2e2b667dac0d066fd37b70706bd Mon Sep 17 00:00:00 2001
+From: Mateo Lelong <mateo.lelong@datadoghq.com>
+Date: Fri, 22 May 2026 11:28:44 +0200
+Subject: [PATCH] [datadog] shim: sandbox size based on cpu shares
+
+---
+ src/libs/kata-types/src/annotations/mod.rs    | 13 +++-
+ .../crates/resource/src/cpu_mem/cpu.rs        | 17 +++++
+ .../resource/src/cpu_mem/initial_size.rs      | 76 ++++++++++++++++++-
+ src/runtime/pkg/oci/utils.go                  | 32 +++++---
+ src/runtime/virtcontainers/sandbox.go         |  2 +-
+ src/runtime/virtcontainers/utils/utils.go     |  8 +-
+ .../virtcontainers/utils/utils_test.go        | 16 +++-
+ 7 files changed, 143 insertions(+), 21 deletions(-)
+
+diff --git a/src/libs/kata-types/src/annotations/mod.rs b/src/libs/kata-types/src/annotations/mod.rs
+index 271872d78..7579cd981 100644
+--- a/src/libs/kata-types/src/annotations/mod.rs
++++ b/src/libs/kata-types/src/annotations/mod.rs
+@@ -17,8 +17,9 @@ use crate::config::TomlConfig;
+ use crate::initdata::add_hypervisor_initdata_overrides;
+ use crate::sl;
+ 
+-use self::cri_containerd::{SANDBOX_CPU_PERIOD_KEY, SANDBOX_CPU_QUOTA_KEY, SANDBOX_MEM_KEY};
+-
++use self::cri_containerd::{
++    SANDBOX_CPU_PERIOD_KEY, SANDBOX_CPU_QUOTA_KEY, SANDBOX_CPU_SHARE_KEY, SANDBOX_MEM_KEY,
++};
+ /// CRI-containerd specific annotations.
+ pub mod cri_containerd;
+ 
+@@ -461,6 +462,14 @@ impl Annotation {
+         value.unwrap_or(0)
+     }
+ 
++    /// Get the annotation of CPU shares for sandbox
++    pub fn get_sandbox_cpu_shares(&self) -> u64 {
++        let value = self
++            .get_value::<u64>(SANDBOX_CPU_SHARE_KEY)
++            .unwrap_or(Some(0));
++        value.unwrap_or(0)
++    }
++
+     /// Get the annotation of memory for sandbox
+     pub fn get_sandbox_mem(&self) -> i64 {
+         let value = self.get_value::<i64>(SANDBOX_MEM_KEY).unwrap_or(Some(0));
+diff --git a/src/runtime-rs/crates/resource/src/cpu_mem/cpu.rs b/src/runtime-rs/crates/resource/src/cpu_mem/cpu.rs
+index 73c8f499f..0e3dec1a3 100644
+--- a/src/runtime-rs/crates/resource/src/cpu_mem/cpu.rs
++++ b/src/runtime-rs/crates/resource/src/cpu_mem/cpu.rs
+@@ -168,6 +168,23 @@ impl CpuResource {
+             return Ok(cpuset_vcpu.len() as f32);
+         }
+ 
++        // Fallback to CPU shares when quota and cpuset are both absent.
++        // This handles pods with no resource limits but with CPU shares set.
++        if total_quota == 0.0 && cpuset_vcpu.is_empty() {
++            let total_shares: u64 = resources
++                .values()
++                .map(|cpu_resource| cpu_resource.shares())
++                .sum();
++            if total_shares > 0 {
++                let shares_vcpu = total_shares as f32 / 1024.0;
++                info!(
++                    sl!(),
++                    "(from cpu_shares) get vcpus # {}", shares_vcpu
++                );
++                return Ok(shares_vcpu.max(1.0));
++            }
++        }
++
+         // When quota is set: calculate vCPUs as quota/period after normalization
+         if total_quota > 0.0 && max_period > 0.0 {
+             let quota_vcpu = total_quota / max_period;
+diff --git a/src/runtime-rs/crates/resource/src/cpu_mem/initial_size.rs b/src/runtime-rs/crates/resource/src/cpu_mem/initial_size.rs
+index 4c35bc09f..5bd08419f 100644
+--- a/src/runtime-rs/crates/resource/src/cpu_mem/initial_size.rs
++++ b/src/runtime-rs/crates/resource/src/cpu_mem/initial_size.rs
+@@ -32,7 +32,7 @@ impl TryFrom<&HashMap<String, String>> for InitialSize {
+ 
+         let annotation = Annotation::new(an.clone());
+         let (period, quota, memory) =
+-            get_sizing_info(annotation).context("failed to get sizing info")?;
++            get_sizing_info(&annotation).context("failed to get sizing info")?;
+         let mut cpu = oci::LinuxCpu::default();
+         cpu.set_period(Some(period));
+         cpu.set_quota(Some(quota));
+@@ -42,6 +42,13 @@ impl TryFrom<&HashMap<String, String>> for InitialSize {
+         if let Ok(cpu_resource) = LinuxContainerCpuResources::try_from(&cpu) {
+             vcpu = get_nr_vcpu(&cpu_resource);
+         }
++
++        // When neither quota/period nor cpuset constrain CPU, fall back to CPU shares annotation
++        let shares = annotation.get_sandbox_cpu_shares();
++        if vcpu == 0.0 && shares > 0 {
++            vcpu = shares as f32 / 1024.0;
++        }
++
+         let mem_mb = convert_memory_to_mb(memory);
+ 
+         Ok(Self {
+@@ -193,7 +200,7 @@ fn convert_memory_to_mb(memory_in_byte: i64) -> u32 {
+ 
+ // from the upper layer runtime's annotation (e.g. crio, k8s), get the *cpu quota,
+ // cpu period and memory limit* for a sandbox/container
+-fn get_sizing_info(annotation: Annotation) -> Result<(u64, i64, i64)> {
++fn get_sizing_info(annotation: &Annotation) -> Result<(u64, i64, i64)> {
+     // since we are *adding* our result to the config, a value of 0 will cause no change
+     // and if the annotation is not assigned (but static resource management is), we will
+     // log a *warning* to fill that with zero value
+@@ -269,6 +276,71 @@ mod tests {
+         .to_vec()
+     }
+ 
++    // Test that sandbox CPU-shares annotation is used as vcpu fallback when
++    // quota and period are absent.
++    #[test]
++    fn test_initial_size_sandbox_cpu_shares_fallback() {
++        let cases: &[(&str, u64, f32)] = &[
++            ("1024 shares = 1.0 vcpu", 1024, 1.0),
++            ("2048 shares = 2.0 vcpu", 2048, 2.0),
++            ("512 shares = 0.5 vcpu", 512, 0.5),
++            ("0 shares = 0.0 vcpu (no fallback)", 0, 0.0),
++        ];
++
++        for (desc, shares, expected_vcpu) in cases {
++            let annotations = HashMap::from([
++                (
++                    cri_containerd::CONTAINER_TYPE_LABEL_KEY.to_string(),
++                    cri_containerd::SANDBOX.to_string(),
++                ),
++                (
++                    cri_containerd::SANDBOX_CPU_SHARE_KEY.to_string(),
++                    format!("{}", shares),
++                ),
++            ]);
++
++            let initial_size = InitialSize::try_from(&annotations).unwrap();
++            assert_eq!(
++                initial_size.vcpu, *expected_vcpu,
++                "{}: got vcpu={}, expected {}",
++                desc, initial_size.vcpu, expected_vcpu
++            );
++        }
++    }
++
++    // Verify quota/period take precedence over shares when both are present.
++    #[test]
++    fn test_initial_size_sandbox_quota_wins_over_shares() {
++        let annotations = HashMap::from([
++            (
++                cri_containerd::CONTAINER_TYPE_LABEL_KEY.to_string(),
++                cri_containerd::SANDBOX.to_string(),
++            ),
++            (
++                cri_containerd::SANDBOX_CPU_PERIOD_KEY.to_string(),
++                "100000".to_string(),
++            ),
++            (
++                cri_containerd::SANDBOX_CPU_QUOTA_KEY.to_string(),
++                "220000".to_string(),
++            ),
++            // shares set too - quota should win
++            (
++                cri_containerd::SANDBOX_CPU_SHARE_KEY.to_string(),
++                "4096".to_string(), // would be 4.0 if shares were used
++            ),
++        ]);
++
++        let initial_size = InitialSize::try_from(&annotations).unwrap();
++        // 220_000/100_000 = 2.2 -> ceil = 3.0, not 4.0 from shares
++        assert_eq!(
++            initial_size.vcpu.ceil(),
++            3.0,
++            "quota should take precedence over shares, got vcpu={}",
++            initial_size.vcpu
++        );
++    }
++
+     #[test]
+     fn test_initial_size_sandbox() {
+         let tests = get_test_data();
+diff --git a/src/runtime/pkg/oci/utils.go b/src/runtime/pkg/oci/utils.go
+index b09a97e99..835265e16 100644
+--- a/src/runtime/pkg/oci/utils.go
++++ b/src/runtime/pkg/oci/utils.go
+@@ -1457,7 +1457,7 @@ func (a *annotationConfiguration) setFloat32WithCheck(f func(float32) error) err
+ // be added to the VM if sandbox annotations are provided with this sizing details
+ func CalculateSandboxSizing(spec *specs.Spec) (numCPU float32, memSizeMB uint32) {
+ 	var memory, quota int64
+-	var period uint64
++	var period, shares uint64
+ 	var err error
+ 
+ 	if spec == nil || spec.Annotations == nil {
+@@ -1488,6 +1488,15 @@ func CalculateSandboxSizing(spec *specs.Spec) (numCPU float32, memSizeMB uint32)
+ 		}
+ 	}
+ 
++	annotation, ok = spec.Annotations[ctrAnnotations.SandboxCPUShares]
++	if ok {
++		shares, err = strconv.ParseUint(annotation, 10, 64)
++		if err != nil {
++			ociLog.Warningf("sandbox-sizing: failure to parse SandboxCPUShares: %s", annotation)
++			shares = 0
++		}
++	}
++
+ 	annotation, ok = spec.Annotations[ctrAnnotations.SandboxMem]
+ 	if ok {
+ 		memory, err = strconv.ParseInt(annotation, 10, 64)
+@@ -1497,14 +1506,14 @@ func CalculateSandboxSizing(spec *specs.Spec) (numCPU float32, memSizeMB uint32)
+ 		}
+ 	}
+ 
+-	return calculateVMResources(period, quota, memory)
++	return calculateVMResources(period, quota, shares, memory)
+ }
+ 
+ // CalculateContainerSizing will calculate the number of CPUs and amount of memory that is needed
+ // based on the provided LinuxResources
+ func CalculateContainerSizing(spec *specs.Spec) (numCPU float32, memSizeMB uint32) {
+ 	var memory, quota int64
+-	var period uint64
++	var period, shares uint64
+ 
+ 	if spec == nil || spec.Linux == nil || spec.Linux.Resources == nil {
+ 		return 0, 0
+@@ -1512,20 +1521,25 @@ func CalculateContainerSizing(spec *specs.Spec) (numCPU float32, memSizeMB uint3
+ 
+ 	resources := spec.Linux.Resources
+ 
+-	if resources.CPU != nil && resources.CPU.Quota != nil && resources.CPU.Period != nil {
+-		quota = *resources.CPU.Quota
+-		period = *resources.CPU.Period
++	if resources.CPU != nil {
++		if resources.CPU.Quota != nil && resources.CPU.Period != nil {
++			quota = *resources.CPU.Quota
++			period = *resources.CPU.Period
++		}
++		if resources.CPU.Shares != nil {
++			shares = *resources.CPU.Shares
++		}
+ 	}
+ 
+ 	if resources.Memory != nil && resources.Memory.Limit != nil {
+ 		memory = *resources.Memory.Limit
+ 	}
+ 
+-	return calculateVMResources(period, quota, memory)
++	return calculateVMResources(period, quota, shares, memory)
+ }
+ 
+-func calculateVMResources(period uint64, quota int64, memory int64) (numCPU float32, memSizeMB uint32) {
+-	numCPU = vcutils.CalculateCPUsF(quota, period)
++func calculateVMResources(period uint64, quota int64, shares uint64, memory int64) (numCPU float32, memSizeMB uint32) {
++	numCPU = vcutils.CalculateCPUsF(quota, period, shares)
+ 
+ 	if memory < 0 {
+ 		// While spec allows for a negative value to indicate unconstrained, we don't
+diff --git a/src/runtime/virtcontainers/sandbox.go b/src/runtime/virtcontainers/sandbox.go
+index 6ceae42de..b2ad06013 100644
+--- a/src/runtime/virtcontainers/sandbox.go
++++ b/src/runtime/virtcontainers/sandbox.go
+@@ -2637,7 +2637,7 @@ func (s *Sandbox) calculateSandboxCPUs() (float32, error) {
+ 
+ 		if cpu := c.Resources.CPU; cpu != nil {
+ 			if cpu.Period != nil && cpu.Quota != nil {
+-				floatCPU += utils.CalculateCPUsF(*cpu.Quota, *cpu.Period)
++				floatCPU += utils.CalculateCPUsF(*cpu.Quota, *cpu.Period, 0)
+ 			}
+ 
+ 			set, err := cpuset.Parse(cpu.Cpus)
+diff --git a/src/runtime/virtcontainers/utils/utils.go b/src/runtime/virtcontainers/utils/utils.go
+index 39bcfde8f..4258a298e 100644
+--- a/src/runtime/virtcontainers/utils/utils.go
++++ b/src/runtime/virtcontainers/utils/utils.go
+@@ -125,8 +125,8 @@ func WriteToFile(path string, data []byte) error {
+ 	return nil
+ }
+ 
+-// CalculateCPUsF converts CPU quota and period to a fraction number
+-func CalculateCPUsF(quota int64, period uint64) float32 {
++// CalculateCPUsF converts CPU quota and period to a fraction number, or default to the CPU shares
++func CalculateCPUsF(quota int64, period, shares uint64) float32 {
+ 	// If quota is -1, it means the CPU resource request is
+ 	// unconstrained.  In that case, we don't currently assign
+ 	// additional CPUs.
+@@ -134,7 +134,9 @@ func CalculateCPUsF(quota int64, period uint64) float32 {
+ 		return float32(quota) / float32(period)
+ 	}
+ 
+-	return 0
++	// If CPU limit is not set (or no CPU limit is enforced),
++	// Default to the CPU requests (i.e. CPU shares)
++	return float32(shares) / 1024.0
+ }
+ 
+ // GetVirtDriveName returns the disk name format for virtio-blk
+diff --git a/src/runtime/virtcontainers/utils/utils_test.go b/src/runtime/virtcontainers/utils/utils_test.go
+index 8361caa1e..06cf10c06 100644
+--- a/src/runtime/virtcontainers/utils/utils_test.go
++++ b/src/runtime/virtcontainers/utils/utils_test.go
+@@ -150,21 +150,29 @@ func TestWriteToFile(t *testing.T) {
+ func TestCalculateCPUsF(t *testing.T) {
+ 	assert := assert.New(t)
+ 
+-	n := CalculateCPUsF(1, 1)
++	n := CalculateCPUsF(1, 1, 0)
+ 	expected := float32(1)
+ 	assert.Equal(n, expected)
+ 
+-	n = CalculateCPUsF(1, 0)
++	n = CalculateCPUsF(1, 0, 0)
+ 	expected = float32(0)
+ 	assert.Equal(n, expected)
+ 
+-	n = CalculateCPUsF(-1, 1)
++	n = CalculateCPUsF(-1, 1, 0)
+ 	expected = float32(0)
+ 	assert.Equal(n, expected)
+ 
+-	n = CalculateCPUsF(500, 1000)
++	n = CalculateCPUsF(500, 1000, 0)
+ 	expected = float32(0.5)
+ 	assert.Equal(n, expected)
++
++	n = CalculateCPUsF(500, 1000, 1024)
++	expected = float32(0.5)
++	assert.Equal(n, expected)
++
++	n = CalculateCPUsF(0, 0, 1024)
++	expected = float32(1)
++	assert.Equal(n, expected)
+ }
+ 
+ func TestGetVirtDriveNameInvalidIndex(t *testing.T) {
+-- 
+2.54.0
+

--- a/patches/global/0006-datadog-feat-install-datadog-agent.patch
+++ b/patches/global/0006-datadog-feat-install-datadog-agent.patch
@@ -1,0 +1,150 @@
+From e2e59e2a47516c327846998b510a3746fbbe54f7 Mon Sep 17 00:00:00 2001
+From: Mateo Lelong <mateo.lelong@datadoghq.com>
+Date: Fri, 22 May 2026 11:29:59 +0200
+Subject: [PATCH] [datadog] feat: install datadog agent
+
+---
+ .../osbuilder/hooks/setup_datadog_keyring.sh  |  7 +++++++
+ .../etc/datadog-agent/system-probe.env        | 15 +++++++++++++++
+ .../system-probe.service                      |  1 +
+ .../etc/systemd/system/system-probe.service   | 19 +++++++++++++++++++
+ .../usr/local/bin/start-system-probe          | 17 +++++++++++++++++
+ .../osbuilder/rootfs-builder/ubuntu/config.sh |  4 ++++
+ .../rootfs-builder/ubuntu/rootfs_lib.sh       |  6 +++++-
+ 7 files changed, 68 insertions(+), 1 deletion(-)
+ create mode 100755 tools/osbuilder/hooks/setup_datadog_keyring.sh
+ create mode 100644 tools/osbuilder/rootfs-builder/datadog-files/etc/datadog-agent/system-probe.env
+ create mode 120000 tools/osbuilder/rootfs-builder/datadog-files/etc/systemd/system/kata-containers.target.wants/system-probe.service
+ create mode 100644 tools/osbuilder/rootfs-builder/datadog-files/etc/systemd/system/system-probe.service
+ create mode 100755 tools/osbuilder/rootfs-builder/datadog-files/usr/local/bin/start-system-probe
+
+diff --git a/tools/osbuilder/hooks/setup_datadog_keyring.sh b/tools/osbuilder/hooks/setup_datadog_keyring.sh
+new file mode 100755
+index 000000000..db1f97bad
+--- /dev/null
++++ b/tools/osbuilder/hooks/setup_datadog_keyring.sh
+@@ -0,0 +1,7 @@
++#!/bin/sh
++# Fetch the Datadog APT signing key
++
++set -e
++
++curl -fsSL https://keys.datadoghq.com/DATADOG_APT_KEY_CURRENT.public \
++    | gpg --dearmor > /tmp/datadog-archive-keyring.gpg
+diff --git a/tools/osbuilder/rootfs-builder/datadog-files/etc/datadog-agent/system-probe.env b/tools/osbuilder/rootfs-builder/datadog-files/etc/datadog-agent/system-probe.env
+new file mode 100644
+index 000000000..e7ba990c7
+--- /dev/null
++++ b/tools/osbuilder/rootfs-builder/datadog-files/etc/datadog-agent/system-probe.env
+@@ -0,0 +1,15 @@
++DD_RUNTIME_SECURITY_CONFIG_EVENT_GRPC_SERVER=security-agent
++DD_RUNTIME_SECURITY_CONFIG_CMD_SOCKET=/tmp/wp-cmd.sock
++DD_VSOCK_ADDR=host
++DD_SYSTEM_PROBE_CONFIG_LOG_FILE=/tmp/system-probe.log
++DD_RUNTIME_SECURITY_CONFIG_ENABLED=true
++DD_SYSTEM_PROBE_CONFIG_SYSPROBE_SOCKET=/tmp/sysprobe.sock
++DD_SYSPROBE_SOCKET=/tmp/sysprobe.sock
++DD_EVENT_MONITORING_CONFIG_SOCKET=/tmp/evt.sock
++DD_RUNTIME_SECURITY_CONFIG_SOCKET=vsock:5020
++DD_RUNTIME_SECURITY_CONFIG_ACTIVITY_DUMP_ENABLED=false
++DD_RUNTIME_SECURITY_CONFIG_SECURITY_PROFILE_ENABLED=false
++DD_RUNTIME_SECURITY_CONFIG_ACTIVITY_DUMP_LOCAL_STORAGE_OUTPUT_DIRECTORY=/tmp
++DD_REMOTE_AGENT_REGISTRY_ENABLED=false
++DD_SYSTEM_PROBE_ORIGIN=kata-containers
++DD_RUNTIME_SECURITY_CONFIG_ENV_AS_TAGS="DD_SYSTEM_PROBE_ORIGIN"
+diff --git a/tools/osbuilder/rootfs-builder/datadog-files/etc/systemd/system/kata-containers.target.wants/system-probe.service b/tools/osbuilder/rootfs-builder/datadog-files/etc/systemd/system/kata-containers.target.wants/system-probe.service
+new file mode 120000
+index 000000000..334e2129e
+--- /dev/null
++++ b/tools/osbuilder/rootfs-builder/datadog-files/etc/systemd/system/kata-containers.target.wants/system-probe.service
+@@ -0,0 +1 @@
++/etc/systemd/system/system-probe.service
+\ No newline at end of file
+diff --git a/tools/osbuilder/rootfs-builder/datadog-files/etc/systemd/system/system-probe.service b/tools/osbuilder/rootfs-builder/datadog-files/etc/systemd/system/system-probe.service
+new file mode 100644
+index 000000000..3489e581f
+--- /dev/null
++++ b/tools/osbuilder/rootfs-builder/datadog-files/etc/systemd/system/system-probe.service
+@@ -0,0 +1,19 @@
++[Unit]
++Description=Datadog System Probe
++Requires=sys-kernel-debug.mount
++After=sys-kernel-debug.mount
++
++[Service]
++Type=simple
++PIDFile=/tmp/system-probe.pid
++Restart=always
++RestartSec=10
++ExecStart=/usr/local/bin/start-system-probe run --pid=/tmp/system-probe.pid
++ExecReload=/bin/kill -HUP $MAINPID
++StartLimitInterval=10
++StartLimitBurst=5
++
++EnvironmentFile=/etc/datadog-agent/system-probe.env
++
++[Install]
++WantedBy=kata-containers.target
+diff --git a/tools/osbuilder/rootfs-builder/datadog-files/usr/local/bin/start-system-probe b/tools/osbuilder/rootfs-builder/datadog-files/usr/local/bin/start-system-probe
+new file mode 100755
+index 000000000..cbf020386
+--- /dev/null
++++ b/tools/osbuilder/rootfs-builder/datadog-files/usr/local/bin/start-system-probe
+@@ -0,0 +1,17 @@
++#!/bin/sh
++
++# Fetch datadog-agent token
++token_path=$(ls /run/kata-containers/shared/containers/*/datadog-agent/auth/token 2>/dev/null | head -n 1)
++[ -n "${token_path}" ] && export DD_AUTH_TOKEN_FILE_PATH="${token_path}"
++
++# Get DD_SITE from container env variables
++for config_path in /run/kata-containers/*/config.json /run/kata-containers/*/*/config.json; do
++    [ -f "${config_path}" ] || continue
++    dd_site=$(grep -oE '"DD_SITE=[^"]+"' "${config_path}" | head -n 1 | sed -e 's/^"DD_SITE=//' -e 's/"$//')
++    if [ -n "${dd_site}" ]; then
++        export DD_SITE="${dd_site}"
++        break
++    fi
++done
++
++exec /opt/datadog-agent/embedded/bin/system-probe "$@"
+diff --git a/tools/osbuilder/rootfs-builder/ubuntu/config.sh b/tools/osbuilder/rootfs-builder/ubuntu/config.sh
+index 9a5f9db9f..ceb1b4fc2 100644
+--- a/tools/osbuilder/rootfs-builder/ubuntu/config.sh
++++ b/tools/osbuilder/rootfs-builder/ubuntu/config.sh
+@@ -31,6 +31,10 @@ case "${ARCH}" in
+ esac
+ REPO_URL=${REPO_URL:-http://ports.ubuntu.com}
+ 
++# [DATADOG] Packages installed from the Datadog APT repo. Repo + keyring are
++# wired into mmdebstrap in rootfs_lib.sh. Append more packages here as needed.
++EXTRA_PKGS="${EXTRA_PKGS:+${EXTRA_PKGS} }datadog-agent"
++
+ if [[ "$(uname -m)" != "${ARCH}" ]]; then
+ 	case "${ARCH}" in
+ 		ppc64le) cc_arch=powerpc64le;;
+diff --git a/tools/osbuilder/rootfs-builder/ubuntu/rootfs_lib.sh b/tools/osbuilder/rootfs-builder/ubuntu/rootfs_lib.sh
+index e8d29688f..29a44733a 100644
+--- a/tools/osbuilder/rootfs-builder/ubuntu/rootfs_lib.sh
++++ b/tools/osbuilder/rootfs-builder/ubuntu/rootfs_lib.sh
+@@ -20,12 +20,16 @@ build_rootfs() {
+ 	# shellcheck disable=SC2154
+ 	if ! mmdebstrap --mode auto --arch "${DEB_ARCH}" --variant required \
+ 			--components="${REPO_COMPONENTS}" \
++			--setup-hook "/kata-containers/tools/osbuilder/hooks/setup_datadog_keyring.sh" \
+ 			--customize-hook "/kata-containers/tools/osbuilder/hooks/download_generate_sbom.sh" \
+-			--include "${PACKAGES},${EXTRA_PKGS}" "${OS_VERSION}" "${rootfs_dir}" "${REPO_URL}"; then
++			--include "${PACKAGES},${EXTRA_PKGS}" "${OS_VERSION}" "${rootfs_dir}" \
++			"${REPO_URL}" \
++			"deb [signed-by=/tmp/datadog-archive-keyring.gpg] https://apt.datadoghq.com/ stable 7"; then
+ 		echo "ERROR: mmdebstrap failed, cannot proceed" && exit 1
+ 	else
+ 		echo "INFO: mmdebstrap succeeded"
+ 	fi
++	rm -f "/tmp/datadog-archive-keyring.gpg"
+ 	rm -rf "${rootfs_dir}/var/run"
+ 	ln -s /run "${rootfs_dir}/var/run"
+ 	cp --remove-destination /etc/resolv.conf "${rootfs_dir}/etc"
+-- 
+2.54.0
+

--- a/patches/global/0007-datadog-kernel-add-datadog-kernel-modules.patch
+++ b/patches/global/0007-datadog-kernel-add-datadog-kernel-modules.patch
@@ -1,0 +1,210 @@
+From 482592b5213862df41daef1c9e50a18f0d421e7b Mon Sep 17 00:00:00 2001
+From: Mateo Lelong <mateo.lelong@datadoghq.com>
+Date: Fri, 22 May 2026 11:51:15 +0200
+Subject: [PATCH] [datadog] kernel: add datadog kernel modules
+
+---
+ .gitlab-ci.yml                                |  1 +
+ tools/packaging/kernel/build-kernel.sh        |  9 +++++
+ .../configs/fragments/common/network.conf     |  3 +-
+ .../configs/fragments/datadog/ebpf.conf       | 35 +++++++++++++++++++
+ .../kernel/configs/fragments/datadog/fs.conf  |  7 ++++
+ .../fragments/datadog/module_signing.conf     | 28 +++++++++++++++
+ .../configs/fragments/datadog/network.conf    |  9 +++++
+ .../configs/fragments/datadog/storage.conf    | 13 +++++++
+ .../kernel/configs/fragments/debug/debug.conf |  1 -
+ 9 files changed, 104 insertions(+), 2 deletions(-)
+ create mode 100644 tools/packaging/kernel/configs/fragments/datadog/ebpf.conf
+ create mode 100644 tools/packaging/kernel/configs/fragments/datadog/fs.conf
+ create mode 100644 tools/packaging/kernel/configs/fragments/datadog/module_signing.conf
+ create mode 100644 tools/packaging/kernel/configs/fragments/datadog/network.conf
+ create mode 100644 tools/packaging/kernel/configs/fragments/datadog/storage.conf
+
+diff --git a/.gitlab-ci.yml b/.gitlab-ci.yml
+index 68513f146..bf51a8947 100644
+--- a/.gitlab-ci.yml
++++ b/.gitlab-ci.yml
+@@ -7,6 +7,7 @@ variables:
+   KUBERNETES_MEMORY_REQUEST: "20Gi"
+   KUBERNETES_MEMORY_LIMIT: "40Gi"
+   KERNEL_DEBUG_ENABLED: "yes"
++  KERNEL_DATADOG_ENABLED: "yes"
+ 
+ stages:
+   - ci-image
+diff --git a/tools/packaging/kernel/build-kernel.sh b/tools/packaging/kernel/build-kernel.sh
+index b82cc393a..764dfb3ff 100755
+--- a/tools/packaging/kernel/build-kernel.sh
++++ b/tools/packaging/kernel/build-kernel.sh
+@@ -35,6 +35,7 @@ readonly VENDOR_INTEL="intel"
+ readonly VENDOR_NVIDIA="nvidia"
+ readonly KBUILD_SIGN_PIN=${KBUILD_SIGN_PIN:-""}
+ readonly KERNEL_DEBUG_ENABLED=${KERNEL_DEBUG_ENABLED:-"no"}
++readonly KERNEL_DATADOG_ENABLED=${KERNEL_DATADOG_ENABLED:-"no"}
+ 
+ #Path to kernel directory
+ kernel_path=""
+@@ -329,6 +330,14 @@ get_kernel_frag_path() {
+ 		all_configs="${all_configs} ${debug_configs}"
+ 	fi
+ 
++	if [[ ${KERNEL_DATADOG_ENABLED} == "yes" ]]; then
++		info "Enable Datadog kernel config"
++		local datadog_path="${arch_path}/../datadog"
++		local datadog_configs
++		datadog_configs="$(find "${datadog_path}" -name '*.conf')"
++		all_configs="${all_configs} ${datadog_configs}"
++	fi
++
+ 	if [[ "${force_setup_generate_config}" == "true" ]]; then
+ 		info "Remove existing config ${config_path} due to '-f'"
+ 		[[ -f "${config_path}" ]] && rm -f "${config_path}"
+diff --git a/tools/packaging/kernel/configs/fragments/common/network.conf b/tools/packaging/kernel/configs/fragments/common/network.conf
+index 8ce90bf8c..29f76a58c 100644
+--- a/tools/packaging/kernel/configs/fragments/common/network.conf
++++ b/tools/packaging/kernel/configs/fragments/common/network.conf
+@@ -80,7 +80,8 @@ CONFIG_MACVLAN=y
+ CONFIG_MACVTAP=y
+ CONFIG_BRIDGE_NETFILTER=y
+ CONFIG_VXLAN=y
+-CONFIG_INET_ESP=y
++# IPsec ESP is not required by default Kata workloads. Keep it disabled.
++# CONFIG_INET_ESP is not set
+ 
+ 
+ # Need netfilter support for iptables
+diff --git a/tools/packaging/kernel/configs/fragments/datadog/ebpf.conf b/tools/packaging/kernel/configs/fragments/datadog/ebpf.conf
+new file mode 100644
+index 000000000..82ccf5448
+--- /dev/null
++++ b/tools/packaging/kernel/configs/fragments/datadog/ebpf.conf
+@@ -0,0 +1,35 @@
++# Datadog-specific eBPF and tracing enhancements for system probe.
++# Extends debug/ebpf.conf — only include this fragment alongside it.
++
++# Loadable modules — BPF JIT requires MODULES; also needed for kmod-based tooling
++CONFIG_MODULES=y
++CONFIG_MODULE_COMPRESS_NONE=y
++
++# OID registry — required for ASN.1/X.509 parsing used by module verification
++CONFIG_OID_REGISTRY=y
++
++# Always JIT-compile BPF programs for consistent and predictable performance
++CONFIG_BPF_JIT_ALWAYS_ON=y
++CONFIG_BPF_JIT_DEFAULT_ON=y
++
++# Kernel return probes — required for uretprobes used by system probe
++CONFIG_KRETPROBES=y
++
++# Core tracing infrastructure — required by perf events and BPF_EVENTS
++CONFIG_TRACEPOINTS=y
++CONFIG_TRACING=y
++CONFIG_EVENT_TRACING=y
++CONFIG_GENERIC_TRACER=y
++CONFIG_RING_BUFFER=y
++
++# Dynamic events and probe infrastructure — required for kprobe/uprobe event creation
++CONFIG_DYNAMIC_EVENTS=y
++CONFIG_PROBE_EVENTS=y
++
++# Disable branch profiling overhead (not needed, avoids sampling noise)
++CONFIG_BRANCH_PROFILE_NONE=y
++
++# ftrace extensions — direct call patching and call graph tracing for system probe
++CONFIG_DYNAMIC_FTRACE_WITH_DIRECT_CALLS=y
++CONFIG_DYNAMIC_FTRACE_WITH_ARGS=y
++CONFIG_FUNCTION_GRAPH_TRACER=y
+diff --git a/tools/packaging/kernel/configs/fragments/datadog/fs.conf b/tools/packaging/kernel/configs/fragments/datadog/fs.conf
+new file mode 100644
+index 000000000..b87c8d101
+--- /dev/null
++++ b/tools/packaging/kernel/configs/fragments/datadog/fs.conf
+@@ -0,0 +1,7 @@
++# FAT/VFAT — required to mount EFI and Windows-formatted volumes from the agent
++CONFIG_FAT_FS=y
++CONFIG_VFAT_FS=y
++
++# National Language Support codepages required by VFAT for filename encoding
++CONFIG_NLS_CODEPAGE_437=y
++CONFIG_NLS_ISO8859_1=y
+diff --git a/tools/packaging/kernel/configs/fragments/datadog/module_signing.conf b/tools/packaging/kernel/configs/fragments/datadog/module_signing.conf
+new file mode 100644
+index 000000000..cf6cfdf8d
+--- /dev/null
++++ b/tools/packaging/kernel/configs/fragments/datadog/module_signing.conf
+@@ -0,0 +1,28 @@
++# Datadog module signing — SHA256 + RSA key, overrides SHA512 in signing/module_signing.conf
++
++# Master switch — enables module signature verification
++CONFIG_MODULE_SIG=y
++CONFIG_MODULE_SIG_ALL=y
++
++# Use SHA256 instead of SHA512 to match the Datadog signing infrastructure
++CONFIG_MODULE_SIG_SHA256=y
++CONFIG_MODULE_SIG_HASH="sha256"
++
++# RSA signing key used to sign Datadog out-of-tree modules
++CONFIG_MODULE_SIG_KEY="certs/signing_key.pem"
++CONFIG_MODULE_SIG_KEY_TYPE_RSA=y
++
++# Asymmetric key infrastructure — required by MODULE_SIG and MODULE_SIG_KEY_TYPE_RSA
++CONFIG_CRYPTO_AKCIPHER=y
++CONFIG_ASYMMETRIC_KEY_TYPE=y
++CONFIG_ASYMMETRIC_PUBLIC_KEY_SUBTYPE=y
++CONFIG_X509_CERTIFICATE_PARSER=y
++CONFIG_PKCS7_MESSAGE_PARSER=y
++
++# Trusted keyring — required for verifying module signatures at load time
++CONFIG_SYSTEM_TRUSTED_KEYRING=y
++CONFIG_SYSTEM_TRUSTED_KEYS=""
++
++# Big-integer math library — required by the RSA implementation
++CONFIG_CLZ_TAB=y
++CONFIG_MPILIB=y
+diff --git a/tools/packaging/kernel/configs/fragments/datadog/network.conf b/tools/packaging/kernel/configs/fragments/datadog/network.conf
+new file mode 100644
+index 000000000..974ae2d6c
+--- /dev/null
++++ b/tools/packaging/kernel/configs/fragments/datadog/network.conf
+@@ -0,0 +1,9 @@
++# Netkit virtual devices — used by system probe for eBPF-based network visibility
++CONFIG_NETKIT=y
++
++# vhost vsock — guest-side of the virtio socket device, needed for system probe
++# communication inside the microVM
++CONFIG_VHOST_VSOCK=y
++
++# emissary dummy interface
++CONFIG_DUMMY=y
+diff --git a/tools/packaging/kernel/configs/fragments/datadog/storage.conf b/tools/packaging/kernel/configs/fragments/datadog/storage.conf
+new file mode 100644
+index 000000000..ab2481ada
+--- /dev/null
++++ b/tools/packaging/kernel/configs/fragments/datadog/storage.conf
+@@ -0,0 +1,13 @@
++# Network block device — used to attach remote volumes to the agent sandbox
++CONFIG_BLK_DEV_NBD=y
++
++# MD (RAID) and device-mapper — required by container runtimes using devicemapper storage
++CONFIG_MD=y
++CONFIG_BLK_DEV_DM_BUILTIN=y
++CONFIG_BLK_DEV_DM=y
++
++# Btrfs — required for container image layers using btrfs storage driver
++CONFIG_BTRFS_FS=y
++
++# F2FS — flash-optimized filesystem, needed for agent storage on SSD-backed volumes
++CONFIG_F2FS_FS=y
+diff --git a/tools/packaging/kernel/configs/fragments/debug/debug.conf b/tools/packaging/kernel/configs/fragments/debug/debug.conf
+index 1ebc115df..960d1ba76 100644
+--- a/tools/packaging/kernel/configs/fragments/debug/debug.conf
++++ b/tools/packaging/kernel/configs/fragments/debug/debug.conf
+@@ -8,5 +8,4 @@ CONFIG_IKCONFIG_PROC=y
+ # Enable debugging features for the kernel
+ CONFIG_DEBUG_INFO=y
+ CONFIG_DEBUG_KERNEL=y
+-CONFIG_DEBUG_FS=y
+ CONFIG_DEBUG_INFO_DWARF_TOOLCHAIN_DEFAULT=y
+-- 
+2.54.0
+

--- a/patches/global/0008-datadog-runtime-fixes-early-closed-stdout-err-on-exe.patch
+++ b/patches/global/0008-datadog-runtime-fixes-early-closed-stdout-err-on-exe.patch
@@ -1,0 +1,46 @@
+From 7002b47d17e8a035ddcbcea222863851b30b8f4a Mon Sep 17 00:00:00 2001
+From: Eric Mountain <eric.mountain@datadoghq.com>
+Date: Thu, 21 Aug 2025 18:11:23 +0200
+Subject: [PATCH] [datadog] runtime: fixes early closed stdout/err on exec w/o
+ stdin option (#26)
+
+An early call to closing the stdin channel made the stdout & stderr also closed.
+This waits for stdout & stderr to be properly finished by reading the whole buffer before closing everything.
+On the other, this also fixes a race condition where it was impossible to run multiple execs until the other one was over.
+This moves the lock only where it is necessary without locking exec processes.
+
+Fixes #10387
+
+Signed-off-by: Maxime Bertin <mbertin@luccasoftware.com>
+Co-authored-by: Maxime Bertin <mbertin@luccasoftware.com>
+---
+ src/runtime/virtcontainers/iostream.go | 8 --------
+ 1 file changed, 8 deletions(-)
+
+diff --git a/src/runtime/virtcontainers/iostream.go b/src/runtime/virtcontainers/iostream.go
+index 691467009..0345009f3 100644
+--- a/src/runtime/virtcontainers/iostream.go
++++ b/src/runtime/virtcontainers/iostream.go
+@@ -78,19 +78,11 @@ func (s *stdinStream) Close() error {
+ }
+ 
+ func (s *stdoutStream) Read(data []byte) (n int, err error) {
+-	if s.closed {
+-		return 0, errors.New("stream closed")
+-	}
+-
+ 	// can not pass context to Read(), so use background context
+ 	return s.sandbox.agent.readProcessStdout(context.Background(), s.container, s.process, data)
+ }
+ 
+ func (s *stderrStream) Read(data []byte) (n int, err error) {
+-	if s.closed {
+-		return 0, errors.New("stream closed")
+-	}
+-
+ 	// can not pass context to Read(), so use background context
+ 	return s.sandbox.agent.readProcessStderr(context.Background(), s.container, s.process, data)
+ }
+-- 
+2.54.0
+

--- a/patches/global/0009-datadog-kernel-Enable-netkit-device-support.patch
+++ b/patches/global/0009-datadog-kernel-Enable-netkit-device-support.patch
@@ -1,0 +1,26 @@
+From f23fe896920b2971440418566a6b52e06b8a3552 Mon Sep 17 00:00:00 2001
+From: Hadrien Patte <hadrien.patte@datadoghq.com>
+Date: Mon, 15 Sep 2025 12:25:39 +0200
+Subject: [PATCH] [datadog] kernel: Enable netkit device support
+
+Signed-off-by: Hadrien Patte <hadrien.patte@datadoghq.com>
+---
+ tools/packaging/kernel/configs/fragments/common/network.conf | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/tools/packaging/kernel/configs/fragments/common/network.conf b/tools/packaging/kernel/configs/fragments/common/network.conf
+index 29f76a58c..e48c0d917 100644
+--- a/tools/packaging/kernel/configs/fragments/common/network.conf
++++ b/tools/packaging/kernel/configs/fragments/common/network.conf
+@@ -72,6 +72,8 @@ CONFIG_NET_VENDOR_INTEL=y
+ 
+ # Add VETH support (necessary for running Docker in the guest)
+ CONFIG_VETH=y
++# Add Netkit devices support
++CONFIG_NETKIT=y
+ # We quite likely need to add others for passthrough and maybe SRIOV support
+ 
+ # We need TUN/TAP support is a must for VPN kinda services
+-- 
+2.54.0
+

--- a/patches/global/0010-datadog-runtime-Add-support-for-netkit-endpoints.patch
+++ b/patches/global/0010-datadog-runtime-Add-support-for-netkit-endpoints.patch
@@ -1,0 +1,668 @@
+From a0d46db99e2e54fa9a8dfc55022e0cccd4ef1166 Mon Sep 17 00:00:00 2001
+From: Mateo Lelong <mateo.lelong@datadoghq.com>
+Date: Mon, 11 May 2026 13:45:24 +0200
+Subject: [PATCH] [datadog] runtime: Add support for netkit endpoints
+
+Add support for [`netkit`](https://git.kernel.org/pub/scm/linux/kernel/git/bpf/bpf-next.git/commit/?id=22360fad5889cbefe1eca695b0cc0273ab280b56) network devices similarly to how `veth` devices are currently handled.
+
+Signed-off-by: Hadrien Patte <hadrien.patte@datadoghq.com>
+---
+ src/runtime/virtcontainers/endpoint.go        |   8 +
+ src/runtime/virtcontainers/endpoint_test.go   |   9 +
+ src/runtime/virtcontainers/netkit_endpoint.go | 216 +++++++++++++++++
+ .../virtcontainers/netkit_endpoint_test.go    | 228 ++++++++++++++++++
+ src/runtime/virtcontainers/network_linux.go   |  19 +-
+ .../virtcontainers/persist/api/network.go     |   5 +
+ src/runtime/virtcontainers/qemu.go            |   2 +-
+ src/runtime/virtcontainers/qemu_arch_base.go  |   2 +-
+ 8 files changed, 483 insertions(+), 6 deletions(-)
+ create mode 100644 src/runtime/virtcontainers/netkit_endpoint.go
+ create mode 100644 src/runtime/virtcontainers/netkit_endpoint_test.go
+
+diff --git a/src/runtime/virtcontainers/endpoint.go b/src/runtime/virtcontainers/endpoint.go
+index f04fdae30..2157078e7 100644
+--- a/src/runtime/virtcontainers/endpoint.go
++++ b/src/runtime/virtcontainers/endpoint.go
+@@ -50,6 +50,9 @@ const (
+ 	// VethEndpointType is the virtual network interface.
+ 	VethEndpointType EndpointType = "virtual"
+ 
++	// NetkitEndpointType is the netkit network interface.
++	NetkitEndpointType EndpointType = "netkit"
++
+ 	// VhostUserEndpointType is the vhostuser network interface.
+ 	VhostUserEndpointType EndpointType = "vhost-user"
+ 
+@@ -85,6 +88,9 @@ func (endpointType *EndpointType) Set(value string) error {
+ 	case "virtual":
+ 		*endpointType = VethEndpointType
+ 		return nil
++	case "netkit":
++		*endpointType = NetkitEndpointType
++		return nil
+ 	case "vhost-user":
+ 		*endpointType = VhostUserEndpointType
+ 		return nil
+@@ -118,6 +124,8 @@ func (endpointType *EndpointType) String() string {
+ 		return string(PhysicalEndpointType)
+ 	case VethEndpointType:
+ 		return string(VethEndpointType)
++	case NetkitEndpointType:
++		return string(NetkitEndpointType)
+ 	case VhostUserEndpointType:
+ 		return string(VhostUserEndpointType)
+ 	case MacvlanEndpointType:
+diff --git a/src/runtime/virtcontainers/endpoint_test.go b/src/runtime/virtcontainers/endpoint_test.go
+index f9f814825..a15aedf57 100644
+--- a/src/runtime/virtcontainers/endpoint_test.go
++++ b/src/runtime/virtcontainers/endpoint_test.go
+@@ -46,6 +46,10 @@ func TestVfioEndpointTypeSet(t *testing.T) {
+ 	testEndpointTypeSet(t, "vfio", VfioEndpointType)
+ }
+ 
++func TestNetkitEndpointTypeSet(t *testing.T) {
++	testEndpointTypeSet(t, "netkit", NetkitEndpointType)
++}
++
+ func TestEndpointTypeSetFailure(t *testing.T) {
+ 	var endpointType EndpointType
+ 
+@@ -82,6 +86,11 @@ func TestMacvtapEndpointTypeString(t *testing.T) {
+ 	testEndpointTypeString(t, &endpointType, string(MacvtapEndpointType))
+ }
+ 
++func TestNetkitEndpointTypeString(t *testing.T) {
++	endpointType := NetkitEndpointType
++	testEndpointTypeString(t, &endpointType, string(NetkitEndpointType))
++}
++
+ func TestIncorrectEndpointTypeString(t *testing.T) {
+ 	var endpointType EndpointType
+ 	testEndpointTypeString(t, &endpointType, "")
+diff --git a/src/runtime/virtcontainers/netkit_endpoint.go b/src/runtime/virtcontainers/netkit_endpoint.go
+new file mode 100644
+index 000000000..9a78aa33a
+--- /dev/null
++++ b/src/runtime/virtcontainers/netkit_endpoint.go
+@@ -0,0 +1,216 @@
++//go:build linux
++
++// Copyright (c) 2025 Datadog, Inc
++//
++// SPDX-License-Identifier: Apache-2.0
++//
++
++package virtcontainers
++
++import (
++	"context"
++	"fmt"
++
++	"github.com/containernetworking/plugins/pkg/ns"
++	persistapi "github.com/kata-containers/kata-containers/src/runtime/virtcontainers/persist/api"
++	vcTypes "github.com/kata-containers/kata-containers/src/runtime/virtcontainers/types"
++)
++
++var netkitTrace = getNetworkTrace(NetkitEndpointType)
++
++// NetkitEndpoint gathers a network pair and its properties.
++type NetkitEndpoint struct {
++	EndpointType       EndpointType
++	PCIPath            vcTypes.PciPath
++	CCWDevice          *vcTypes.CcwDevice
++	EndpointProperties NetworkInfo
++	NetPair            NetworkInterfacePair
++	RxRateLimiter      bool
++	TxRateLimiter      bool
++}
++
++func createNetkitNetworkEndpoint(idx int, ifName string, interworkingModel NetInterworkingModel) (*NetkitEndpoint, error) {
++	if idx < 0 {
++		return &NetkitEndpoint{}, fmt.Errorf("invalid network endpoint index: %d", idx)
++	}
++
++	netPair, err := createNetworkInterfacePair(idx, ifName, interworkingModel)
++	if err != nil {
++		return nil, err
++	}
++
++	endpoint := &NetkitEndpoint{
++		// TODO This is too specific. We may need to create multiple
++		// end point types here and then decide how to connect them
++		// at the time of hypervisor attach and not here
++		NetPair:      netPair,
++		EndpointType: NetkitEndpointType,
++	}
++	if ifName != "" {
++		endpoint.NetPair.VirtIface.Name = ifName
++	}
++
++	return endpoint, nil
++}
++
++// Properties returns properties for the netkit interface in the network pair.
++func (endpoint *NetkitEndpoint) Properties() NetworkInfo {
++	return endpoint.EndpointProperties
++}
++
++// Name returns name of the netkit interface in the network pair.
++func (endpoint *NetkitEndpoint) Name() string {
++	return endpoint.NetPair.VirtIface.Name
++}
++
++// HardwareAddr returns the mac address that is assigned to the tap interface
++// in th network pair.
++func (endpoint *NetkitEndpoint) HardwareAddr() string {
++	return endpoint.NetPair.TAPIface.HardAddr
++}
++
++// Type identifies the endpoint as a netkit endpoint.
++func (endpoint *NetkitEndpoint) Type() EndpointType {
++	return endpoint.EndpointType
++}
++
++// PciPath returns the PCI path of the endpoint.
++func (endpoint *NetkitEndpoint) PciPath() vcTypes.PciPath {
++	return endpoint.PCIPath
++}
++
++// SetPciPath sets the PCI path of the endpoint.
++func (endpoint *NetkitEndpoint) SetPciPath(pciPath vcTypes.PciPath) {
++	endpoint.PCIPath = pciPath
++}
++
++// CcwDevice returns the CCW device of the endpoint.
++func (endpoint *NetkitEndpoint) CcwDevice() *vcTypes.CcwDevice {
++	return endpoint.CCWDevice
++}
++
++// SetCcwDevice sets the CCW device of the endpoint.
++func (endpoint *NetkitEndpoint) SetCcwDevice(ccwDev vcTypes.CcwDevice) {
++	endpoint.CCWDevice = &ccwDev
++}
++
++// NetworkPair returns the network pair of the endpoint.
++func (endpoint *NetkitEndpoint) NetworkPair() *NetworkInterfacePair {
++	return &endpoint.NetPair
++}
++
++// SetProperties sets the properties for the endpoint.
++func (endpoint *NetkitEndpoint) SetProperties(properties NetworkInfo) {
++	endpoint.EndpointProperties = properties
++}
++
++// Attach for netkit endpoint bridges the network pair and adds the
++// tap interface of the network pair to the hypervisor.
++func (endpoint *NetkitEndpoint) Attach(ctx context.Context, s *Sandbox) error {
++	span, ctx := netkitTrace(ctx, "Attach", endpoint)
++	defer span.End()
++
++	h := s.hypervisor
++	if err := xConnectVMNetwork(ctx, endpoint, h); err != nil {
++		networkLogger().WithError(err).Error("Error bridging netkit endpoint")
++		return err
++	}
++
++	return h.AddDevice(ctx, endpoint, NetDev)
++}
++
++// Detach for the netkit endpoint tears down the tap and bridge
++// created for the netkit interface.
++func (endpoint *NetkitEndpoint) Detach(ctx context.Context, netNsCreated bool, netNsPath string) error {
++	// The network namespace would have been deleted at this point
++	// if it has not been created by virtcontainers.
++	if !netNsCreated {
++		return nil
++	}
++
++	span, ctx := netkitTrace(ctx, "Detach", endpoint)
++	defer span.End()
++
++	return doNetNS(netNsPath, func(_ ns.NetNS) error {
++		return xDisconnectVMNetwork(ctx, endpoint)
++	})
++}
++
++// HotAttach for the netkit endpoint uses hot plug device
++func (endpoint *NetkitEndpoint) HotAttach(ctx context.Context, s *Sandbox) error {
++	span, ctx := netkitTrace(ctx, "HotAttach", endpoint)
++	defer span.End()
++
++	h := s.hypervisor
++	if err := xConnectVMNetwork(ctx, endpoint, h); err != nil {
++		networkLogger().WithError(err).Error("Error bridging netkit ep")
++		return err
++	}
++
++	if _, err := h.HotplugAddDevice(ctx, endpoint, NetDev); err != nil {
++		networkLogger().WithError(err).Error("Error attach netkit ep")
++		return err
++	}
++	return nil
++}
++
++// HotDetach for the netkit endpoint uses hot pull device
++func (endpoint *NetkitEndpoint) HotDetach(ctx context.Context, s *Sandbox, netNsCreated bool, netNsPath string) error {
++	if !netNsCreated {
++		return nil
++	}
++
++	span, ctx := netkitTrace(ctx, "HotDetach", endpoint)
++	defer span.End()
++
++	if err := doNetNS(netNsPath, func(_ ns.NetNS) error {
++		return xDisconnectVMNetwork(ctx, endpoint)
++	}); err != nil {
++		networkLogger().WithError(err).Warn("Error un-bridging netkit ep")
++	}
++
++	h := s.hypervisor
++	if _, err := h.HotplugRemoveDevice(ctx, endpoint, NetDev); err != nil {
++		networkLogger().WithError(err).Error("Error detach netkit ep")
++		return err
++	}
++	return nil
++}
++
++func (endpoint *NetkitEndpoint) save() persistapi.NetworkEndpoint {
++	netpair := saveNetIfPair(&endpoint.NetPair)
++
++	return persistapi.NetworkEndpoint{
++		Type: string(endpoint.Type()),
++		Netkit: &persistapi.NetkitEndpoint{
++			NetPair: *netpair,
++		},
++	}
++}
++
++func (endpoint *NetkitEndpoint) load(s persistapi.NetworkEndpoint) {
++	endpoint.EndpointType = NetkitEndpointType
++
++	if s.Netkit != nil {
++		netpair := loadNetIfPair(&s.Netkit.NetPair)
++		endpoint.NetPair = *netpair
++	}
++}
++
++func (endpoint *NetkitEndpoint) GetRxRateLimiter() bool {
++	return endpoint.RxRateLimiter
++}
++
++func (endpoint *NetkitEndpoint) SetRxRateLimiter() error {
++	endpoint.RxRateLimiter = true
++	return nil
++}
++
++func (endpoint *NetkitEndpoint) GetTxRateLimiter() bool {
++	return endpoint.TxRateLimiter
++}
++
++func (endpoint *NetkitEndpoint) SetTxRateLimiter() error {
++	endpoint.TxRateLimiter = true
++	return nil
++}
+diff --git a/src/runtime/virtcontainers/netkit_endpoint_test.go b/src/runtime/virtcontainers/netkit_endpoint_test.go
+new file mode 100644
+index 000000000..260fb73f0
+--- /dev/null
++++ b/src/runtime/virtcontainers/netkit_endpoint_test.go
+@@ -0,0 +1,228 @@
++//go:build linux
++
++// Copyright (c) 2025 Datadog, Inc
++//
++// SPDX-License-Identifier: Apache-2.0
++//
++
++package virtcontainers
++
++import (
++	"net"
++	"testing"
++
++	"github.com/stretchr/testify/assert"
++	"github.com/vishvananda/netlink"
++
++	vcTypes "github.com/kata-containers/kata-containers/src/runtime/virtcontainers/types"
++)
++
++func TestCreateNetkitNetworkEndpoint(t *testing.T) {
++	assert := assert.New(t)
++	macAddr := net.HardwareAddr{0x02, 0x00, 0xCA, 0xFE, 0x00, 0x04}
++
++	expected := &NetkitEndpoint{
++		NetPair: NetworkInterfacePair{
++			TapInterface: TapInterface{
++				ID:   "uniqueTestID-4",
++				Name: "br4_kata",
++				TAPIface: NetworkInterface{
++					Name: "tap4_kata",
++				},
++			},
++			VirtIface: NetworkInterface{
++				Name:     "eth4",
++				HardAddr: macAddr.String(),
++			},
++			NetInterworkingModel: DefaultNetInterworkingModel,
++		},
++		EndpointType: NetkitEndpointType,
++	}
++
++	result, err := createNetkitNetworkEndpoint(4, "", DefaultNetInterworkingModel)
++	assert.NoError(err)
++
++	// the resulting ID  will be random - so let's overwrite to test the rest of the flow
++	result.NetPair.ID = "uniqueTestID-4"
++
++	// the resulting mac address will be random - so lets overwrite it
++	result.NetPair.VirtIface.HardAddr = macAddr.String()
++
++	assert.Exactly(result, expected)
++}
++
++func TestCreateNetkitNetworkEndpointChooseIfaceName(t *testing.T) {
++	assert := assert.New(t)
++	macAddr := net.HardwareAddr{0x02, 0x00, 0xCA, 0xFE, 0x00, 0x04}
++
++	expected := &NetkitEndpoint{
++		NetPair: NetworkInterfacePair{
++			TapInterface: TapInterface{
++				ID:   "uniqueTestID-4",
++				Name: "br4_kata",
++				TAPIface: NetworkInterface{
++					Name: "tap4_kata",
++				},
++			},
++			VirtIface: NetworkInterface{
++				Name:     "eth1",
++				HardAddr: macAddr.String(),
++			},
++			NetInterworkingModel: DefaultNetInterworkingModel,
++		},
++		EndpointType: NetkitEndpointType,
++	}
++
++	result, err := createNetkitNetworkEndpoint(4, "eth1", DefaultNetInterworkingModel)
++	assert.NoError(err)
++
++	// the resulting ID will be random - so let's overwrite to test the rest of the flow
++	result.NetPair.ID = "uniqueTestID-4"
++
++	// the resulting mac address will be random - so lets overwrite it
++	result.NetPair.VirtIface.HardAddr = macAddr.String()
++
++	assert.Exactly(result, expected)
++}
++
++func TestCreateNetkitNetworkEndpointInvalidArgs(t *testing.T) {
++	// nolint: govet
++	type endpointValues struct {
++		idx    int
++		ifName string
++	}
++
++	assert := assert.New(t)
++
++	// all elements are expected to result in failure
++	failingValues := []endpointValues{
++		{-1, "bar"},
++		{-1, ""},
++	}
++
++	for _, d := range failingValues {
++		_, err := createNetkitNetworkEndpoint(d.idx, d.ifName, DefaultNetInterworkingModel)
++		assert.Error(err)
++	}
++}
++
++func TestNetkitEndpointProperties(t *testing.T) {
++	assert := assert.New(t)
++
++	endpoint, err := createNetkitNetworkEndpoint(0, "", DefaultNetInterworkingModel)
++	assert.NoError(err)
++
++	// Test Properties
++	properties := NetworkInfo{
++		Iface: NetlinkIface{
++			LinkAttrs: netlink.LinkAttrs{
++				Name: "test-netkit",
++			},
++			Type: "netkit",
++		},
++	}
++	endpoint.SetProperties(properties)
++	assert.Equal(properties, endpoint.Properties())
++
++	// Test Name
++	assert.Equal(endpoint.NetPair.VirtIface.Name, endpoint.Name())
++
++	// Test HardwareAddr
++	assert.Equal(endpoint.NetPair.TAPIface.HardAddr, endpoint.HardwareAddr())
++
++	// Test Type
++	assert.Equal(NetkitEndpointType, endpoint.Type())
++
++	// Test NetworkPair
++	netPair := endpoint.NetworkPair()
++	assert.NotNil(netPair)
++	assert.Equal(&endpoint.NetPair, netPair)
++}
++
++func TestNetkitEndpointPciPath(t *testing.T) {
++	assert := assert.New(t)
++
++	endpoint, err := createNetkitNetworkEndpoint(0, "", DefaultNetInterworkingModel)
++	assert.NoError(err)
++
++	// Test PciPath get/set
++	testPciPath := vcTypes.PciPath{Bus: "0x01", Device: "0x02", Function: "0x03"}
++	endpoint.SetPciPath(testPciPath)
++	assert.Equal(testPciPath, endpoint.PciPath())
++}
++
++func TestNetkitEndpointCcwDevice(t *testing.T) {
++	assert := assert.New(t)
++
++	endpoint, err := createNetkitNetworkEndpoint(0, "", DefaultNetInterworkingModel)
++	assert.NoError(err)
++
++	// Test CcwDevice get/set
++	testCcwDev := vcTypes.CcwDevice{DevNo: "fe.0.0001"}
++	endpoint.SetCcwDevice(testCcwDev)
++	ccwDevice := endpoint.CcwDevice()
++	assert.NotNil(ccwDevice)
++	assert.Equal(testCcwDev, *ccwDevice)
++}
++
++func TestNetkitEndpointRateLimiters(t *testing.T) {
++	assert := assert.New(t)
++
++	endpoint, err := createNetkitNetworkEndpoint(0, "", DefaultNetInterworkingModel)
++	assert.NoError(err)
++
++	// Test RxRateLimiter
++	assert.False(endpoint.GetRxRateLimiter())
++	err = endpoint.SetRxRateLimiter()
++	assert.NoError(err)
++	assert.True(endpoint.GetRxRateLimiter())
++
++	// Test TxRateLimiter
++	assert.False(endpoint.GetTxRateLimiter())
++	err = endpoint.SetTxRateLimiter()
++	assert.NoError(err)
++	assert.True(endpoint.GetTxRateLimiter())
++}
++
++func TestNetkitEndpointSaveLoad(t *testing.T) {
++	assert := assert.New(t)
++	macAddr := net.HardwareAddr{0x02, 0x00, 0xCA, 0xFE, 0x00, 0x05}
++
++	endpoint := &NetkitEndpoint{
++		NetPair: NetworkInterfacePair{
++			TapInterface: TapInterface{
++				ID:   "test-netkit-id",
++				Name: "br5_kata",
++				TAPIface: NetworkInterface{
++					Name:     "tap5_kata",
++					HardAddr: macAddr.String(),
++				},
++			},
++			VirtIface: NetworkInterface{
++				Name:     "eth5",
++				HardAddr: macAddr.String(),
++			},
++			NetInterworkingModel: NetXConnectTCFilterModel,
++		},
++		EndpointType: NetkitEndpointType,
++	}
++
++	// Save the endpoint
++	saved := endpoint.save()
++	assert.Equal(string(NetkitEndpointType), saved.Type)
++	assert.NotNil(saved.Netkit)
++	assert.Equal("test-netkit-id", saved.Netkit.NetPair.TapInterface.ID)
++	assert.Equal("br5_kata", saved.Netkit.NetPair.TapInterface.Name)
++	assert.Equal("eth5", saved.Netkit.NetPair.VirtIface.Name)
++
++	// Load into a new endpoint
++	newEndpoint := &NetkitEndpoint{}
++	newEndpoint.load(saved)
++
++	assert.Equal(NetkitEndpointType, newEndpoint.EndpointType)
++	assert.Equal(endpoint.NetPair.ID, newEndpoint.NetPair.ID)
++	assert.Equal(endpoint.NetPair.Name, newEndpoint.NetPair.Name)
++	assert.Equal(endpoint.NetPair.TAPIface.Name, newEndpoint.NetPair.TAPIface.Name)
++	assert.Equal(endpoint.NetPair.VirtIface.Name, newEndpoint.NetPair.VirtIface.Name)
++	assert.Equal(endpoint.NetPair.NetInterworkingModel, newEndpoint.NetPair.NetInterworkingModel)
++}
+diff --git a/src/runtime/virtcontainers/network_linux.go b/src/runtime/virtcontainers/network_linux.go
+index 9bee440a0..8308daa0a 100644
+--- a/src/runtime/virtcontainers/network_linux.go
++++ b/src/runtime/virtcontainers/network_linux.go
+@@ -100,6 +100,8 @@ func LoadNetwork(netInfo persistapi.NetworkInfo) Network {
+ 			ep = &PhysicalEndpoint{}
+ 		case VethEndpointType:
+ 			ep = &VethEndpoint{}
++		case NetkitEndpointType:
++			ep = &NetkitEndpoint{}
+ 		case VhostUserEndpointType:
+ 			ep = &VhostUserEndpoint{}
+ 		case MacvlanEndpointType:
+@@ -203,6 +205,9 @@ func (n *LinuxNetwork) addSingleEndpoint(ctx context.Context, s *Sandbox, netInf
+ 		} else if netInfo.Iface.Type == "veth" {
+ 			networkLogger().Info("veth interface found")
+ 			endpoint, err = createVethNetworkEndpoint(idx, netInfo.Iface.Name, n.interworkingModel)
++		} else if netInfo.Iface.Type == "netkit" {
++			networkLogger().Info("netkit interface found")
++			endpoint, err = createNetkitNetworkEndpoint(idx, netInfo.Iface.Name, n.interworkingModel)
+ 		} else if netInfo.Iface.Type == "ipvlan" {
+ 			networkLogger().Info("ipvlan interface found")
+ 			endpoint, err = createIPVlanNetworkEndpoint(idx, netInfo.Iface.Name)
+@@ -808,6 +813,8 @@ func getLinkForEndpoint(endpoint Endpoint, netHandle *netlink.Handle) (netlink.L
+ 		return getLinkByName(netHandle, name, &netlink.IPVlan{})
+ 	case *TuntapEndpoint:
+ 		return getLinkByName(netHandle, name, &netlink.Tuntap{})
++	case *NetkitEndpoint:
++		return getLinkByName(netHandle, name, &netlink.Netkit{})
+ 	default:
+ 		return nil, fmt.Errorf("Unexpected endpointType %s", endpoint.Type())
+ 	}
+@@ -828,6 +835,10 @@ func getLinkByName(netHandle *netlink.Handle, name string, expectedLink netlink.
+ 		if l, ok := link.(*netlink.Veth); ok {
+ 			return l, nil
+ 		}
++	case (&netlink.Netkit{}).Type():
++		if l, ok := link.(*netlink.Netkit); ok {
++			return l, nil
++		}
+ 	case (&netlink.Macvtap{}).Type():
+ 		if l, ok := link.(*netlink.Macvtap); ok {
+ 			return l, nil
+@@ -1449,7 +1460,7 @@ func networkInfoFromLink(handle *netlink.Handle, link netlink.Link) (NetworkInfo
+ func addRxRateLimiter(endpoint Endpoint, maxRate uint64) error {
+ 	var linkName string
+ 	switch ep := endpoint.(type) {
+-	case *VethEndpoint, *IPVlanEndpoint, *TuntapEndpoint, *MacvlanEndpoint:
++	case *VethEndpoint, *NetkitEndpoint, *IPVlanEndpoint, *TuntapEndpoint, *MacvlanEndpoint:
+ 		netPair := endpoint.NetworkPair()
+ 		linkName = netPair.TAPIface.Name
+ 	case *MacvtapEndpoint, *TapEndpoint:
+@@ -1606,7 +1617,7 @@ func addTxRateLimiter(endpoint Endpoint, maxRate uint64) error {
+ 	var netPair *NetworkInterfacePair
+ 	var linkName string
+ 	switch ep := endpoint.(type) {
+-	case *VethEndpoint, *IPVlanEndpoint, *TuntapEndpoint, *MacvlanEndpoint:
++	case *VethEndpoint, *NetkitEndpoint, *IPVlanEndpoint, *TuntapEndpoint, *MacvlanEndpoint:
+ 		netPair = endpoint.NetworkPair()
+ 		switch netPair.NetInterworkingModel {
+ 		// For those endpoints we've already used tcfilter as their inter-networking model,
+@@ -1679,7 +1690,7 @@ func removeHTBQdisc(linkName string) error {
+ func removeRxRateLimiter(endpoint Endpoint, networkNSPath string) error {
+ 	var linkName string
+ 	switch ep := endpoint.(type) {
+-	case *VethEndpoint, *IPVlanEndpoint, *TuntapEndpoint, *MacvlanEndpoint:
++	case *VethEndpoint, *NetkitEndpoint, *IPVlanEndpoint, *TuntapEndpoint, *MacvlanEndpoint:
+ 		netPair := endpoint.NetworkPair()
+ 		linkName = netPair.TAPIface.Name
+ 	case *MacvtapEndpoint, *TapEndpoint:
+@@ -1700,7 +1711,7 @@ func removeRxRateLimiter(endpoint Endpoint, networkNSPath string) error {
+ func removeTxRateLimiter(endpoint Endpoint, networkNSPath string) error {
+ 	var linkName string
+ 	switch ep := endpoint.(type) {
+-	case *VethEndpoint, *IPVlanEndpoint, *TuntapEndpoint, *MacvlanEndpoint:
++	case *VethEndpoint, *NetkitEndpoint, *IPVlanEndpoint, *TuntapEndpoint, *MacvlanEndpoint:
+ 		netPair := endpoint.NetworkPair()
+ 		switch netPair.NetInterworkingModel {
+ 		case NetXConnectTCFilterModel:
+diff --git a/src/runtime/virtcontainers/persist/api/network.go b/src/runtime/virtcontainers/persist/api/network.go
+index 256ce807b..9dc484d8e 100644
+--- a/src/runtime/virtcontainers/persist/api/network.go
++++ b/src/runtime/virtcontainers/persist/api/network.go
+@@ -68,6 +68,10 @@ type VethEndpoint struct {
+ 	NetPair NetworkInterfacePair
+ }
+ 
++type NetkitEndpoint struct {
++	NetPair NetworkInterfacePair
++}
++
+ type IPVlanEndpoint struct {
+ 	NetPair NetworkInterfacePair
+ }
+@@ -88,6 +92,7 @@ type NetworkEndpoint struct {
+ 	// One and only one of these below are not nil according to Type.
+ 	Physical  *PhysicalEndpoint  `json:",omitempty"`
+ 	Veth      *VethEndpoint      `json:",omitempty"`
++	Netkit    *NetkitEndpoint    `json:",omitempty"`
+ 	VhostUser *VhostUserEndpoint `json:",omitempty"`
+ 	Macvlan   *MacvlanEndpoint   `json:",omitempty"`
+ 	Macvtap   *MacvtapEndpoint   `json:",omitempty"`
+diff --git a/src/runtime/virtcontainers/qemu.go b/src/runtime/virtcontainers/qemu.go
+index 4066c85e4..f53382f8e 100644
+--- a/src/runtime/virtcontainers/qemu.go
++++ b/src/runtime/virtcontainers/qemu.go
+@@ -1991,7 +1991,7 @@ func (q *qemu) hotplugNetDevice(ctx context.Context, endpoint Endpoint, op Opera
+ 	var tap TapInterface
+ 
+ 	switch endpoint.Type() {
+-	case VethEndpointType, IPVlanEndpointType, MacvlanEndpointType, TuntapEndpointType:
++	case VethEndpointType, NetkitEndpointType, IPVlanEndpointType, MacvlanEndpointType, TuntapEndpointType:
+ 		tap = endpoint.NetworkPair().TapInterface
+ 	case TapEndpointType:
+ 		drive := endpoint.(*TapEndpoint)
+diff --git a/src/runtime/virtcontainers/qemu_arch_base.go b/src/runtime/virtcontainers/qemu_arch_base.go
+index aacb97b7c..cc2ef7875 100644
+--- a/src/runtime/virtcontainers/qemu_arch_base.go
++++ b/src/runtime/virtcontainers/qemu_arch_base.go
+@@ -583,7 +583,7 @@ func networkModelToQemuType(model NetInterworkingModel) govmmQemu.NetDeviceType
+ func genericNetwork(endpoint Endpoint, vhost, nestedRun bool, index int) (govmmQemu.NetDevice, error) {
+ 	var d govmmQemu.NetDevice
+ 	switch ep := endpoint.(type) {
+-	case *VethEndpoint, *MacvlanEndpoint, *IPVlanEndpoint:
++	case *VethEndpoint, *NetkitEndpoint, *MacvlanEndpoint, *IPVlanEndpoint:
+ 		netPair := ep.NetworkPair()
+ 		d = govmmQemu.NetDevice{
+ 			Type:          networkModelToQemuType(netPair.NetInterworkingModel),
+-- 
+2.54.0
+

--- a/patches/global/0011-datadog-runtime-Reject-netkit-L3-devices-with-clear-.patch
+++ b/patches/global/0011-datadog-runtime-Reject-netkit-L3-devices-with-clear-.patch
@@ -1,0 +1,46 @@
+From ee627e36cc485dfb933fb52d576eada8162c8de2 Mon Sep 17 00:00:00 2001
+From: Hadrien Patte <hadrien.patte@datadoghq.com>
+Date: Thu, 27 Nov 2025 18:52:45 +0100
+Subject: [PATCH] [datadog] runtime: Reject netkit L3 devices with clear error
+
+Netkit devices in L3 mode have no MAC address and require IP routing
+instead of L2 bridging. Since L3 routing is not currently implemented,
+reject these devices early with a clear error message directing users
+to use netkit L2 mode or veth devices instead.
+
+Signed-off-by: Hadrien Patte <hadrien.patte@datadoghq.com>
+---
+ src/runtime/virtcontainers/network_linux.go | 10 ++++++++++
+ 1 file changed, 10 insertions(+)
+
+diff --git a/src/runtime/virtcontainers/network_linux.go b/src/runtime/virtcontainers/network_linux.go
+index 8308daa0a..dba536ee2 100644
+--- a/src/runtime/virtcontainers/network_linux.go
++++ b/src/runtime/virtcontainers/network_linux.go
+@@ -1036,6 +1036,11 @@ func tapNetworkPair(ctx context.Context, endpoint Endpoint, queues int, disableV
+ 	// bridge created by the network plugin on the host actually expects
+ 	// to see traffic from this MAC address and not another one.
+ 	tapHardAddr := attrs.HardwareAddr
++	if len(attrs.HardwareAddr) == 0 {
++		// L3 devices (e.g., netkit in L3 mode) have no MAC address and are not currently supported.
++		// They require IP routing instead of L2 bridging, which is not yet implemented.
++		return fmt.Errorf("Device %s has no MAC address (netkit L3 mode is not supported - use netkit L2 mode or veth devices)", attrs.Name)
++	}
+ 	netPair.TAPIface.HardAddr = attrs.HardwareAddr.String()
+ 
+ 	if err := netHandle.LinkSetMTU(tapLink, attrs.MTU); err != nil {
+@@ -1133,6 +1138,11 @@ func setupTCFiltering(ctx context.Context, endpoint Endpoint, queues int, disabl
+ 	// the one inside the VM in order to avoid any firewall issues. The
+ 	// bridge created by the network plugin on the host actually expects
+ 	// to see traffic from this MAC address and not another one.
++	if len(attrs.HardwareAddr) == 0 {
++		// L3 devices (e.g., netkit in L3 mode) have no MAC address and are not currently supported.
++		// They require IP routing instead of L2 bridging, which is not yet implemented.
++		return fmt.Errorf("Device %s has no MAC address (netkit L3 mode is not supported - use netkit L2 mode or veth devices)", attrs.Name)
++	}
+ 	netPair.TAPIface.HardAddr = attrs.HardwareAddr.String()
+ 
+ 	if err := netHandle.LinkSetMTU(tapLink, attrs.MTU); err != nil {
+-- 
+2.54.0
+

--- a/patches/global/0012-datadog-runtime-rs-add-netkit-endpoint-support.patch
+++ b/patches/global/0012-datadog-runtime-rs-add-netkit-endpoint-support.patch
@@ -1,0 +1,258 @@
+From a3d26fbc84c7247693bb4dcad36cf7377c37cfe7 Mon Sep 17 00:00:00 2001
+From: Mateo Lelong <mateo.lelong@datadoghq.com>
+Date: Thu, 9 Apr 2026 17:12:25 +0200
+Subject: [PATCH] [datadog] runtime-rs: add netkit endpoint support
+
+Port the Go runtime netkit endpoint to runtime-rs. Add NetkitEndpoint
+modeled after VethEndpoint with L3-mode detection. Handle InfoKind::Netkit
+and InfoData::Netkit in link_info() to avoid "unsupported link type: device"
+errors on netkit interfaces (kernel sends [Kind, Data] in LIFO order via
+pop(), Data arm must be handled before Kind fires).
+
+Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
+---
+ .../src/network/endpoint/endpoint_persist.rs  |   7 ++
+ .../resource/src/network/endpoint/mod.rs      |   2 +
+ .../src/network/endpoint/netkit_endpoint.rs   | 115 ++++++++++++++++++
+ .../src/network/network_with_netns.rs         |  23 +++-
+ .../src/network/utils/link/manager.rs         |   9 ++
+ 5 files changed, 155 insertions(+), 1 deletion(-)
+ create mode 100644 src/runtime-rs/crates/resource/src/network/endpoint/netkit_endpoint.rs
+
+diff --git a/src/runtime-rs/crates/resource/src/network/endpoint/endpoint_persist.rs b/src/runtime-rs/crates/resource/src/network/endpoint/endpoint_persist.rs
+index 31507c209..3783827a0 100644
+--- a/src/runtime-rs/crates/resource/src/network/endpoint/endpoint_persist.rs
++++ b/src/runtime-rs/crates/resource/src/network/endpoint/endpoint_persist.rs
+@@ -33,6 +33,12 @@ pub struct VethEndpointState {
+     pub network_qos: bool,
+ }
+ 
++#[derive(Serialize, Deserialize, Clone, Default)]
++pub struct NetkitEndpointState {
++    pub if_name: String,
++    pub network_qos: bool,
++}
++
+ #[derive(Serialize, Deserialize, Clone, Default)]
+ pub struct IpVlanEndpointState {
+     pub if_name: String,
+@@ -54,6 +60,7 @@ pub struct VhostUserEndpointState {
+ pub struct EndpointState {
+     pub physical_endpoint: Option<PhysicalEndpointState>,
+     pub veth_endpoint: Option<VethEndpointState>,
++    pub netkit_endpoint: Option<NetkitEndpointState>,
+     pub ipvlan_endpoint: Option<IpVlanEndpointState>,
+     pub macvlan_endpoint: Option<MacvlanEndpointState>,
+     pub vlan_endpoint: Option<VlanEndpointState>,
+diff --git a/src/runtime-rs/crates/resource/src/network/endpoint/mod.rs b/src/runtime-rs/crates/resource/src/network/endpoint/mod.rs
+index 2277dfb7e..9a91f7622 100644
+--- a/src/runtime-rs/crates/resource/src/network/endpoint/mod.rs
++++ b/src/runtime-rs/crates/resource/src/network/endpoint/mod.rs
+@@ -8,6 +8,8 @@ mod physical_endpoint;
+ pub use physical_endpoint::PhysicalEndpoint;
+ mod veth_endpoint;
+ pub use veth_endpoint::VethEndpoint;
++mod netkit_endpoint;
++pub use netkit_endpoint::NetkitEndpoint;
+ mod ipvlan_endpoint;
+ pub use ipvlan_endpoint::IPVlanEndpoint;
+ mod vlan_endpoint;
+diff --git a/src/runtime-rs/crates/resource/src/network/endpoint/netkit_endpoint.rs b/src/runtime-rs/crates/resource/src/network/endpoint/netkit_endpoint.rs
+new file mode 100644
+index 000000000..74d29421b
+--- /dev/null
++++ b/src/runtime-rs/crates/resource/src/network/endpoint/netkit_endpoint.rs
+@@ -0,0 +1,115 @@
++// Copyright (c) 2019-2022 Alibaba Cloud
++// Copyright (c) 2019-2022 Ant Group
++//
++// SPDX-License-Identifier: Apache-2.0
++//
++
++use std::io::{self, Error};
++use std::sync::Arc;
++
++use anyhow::{Context, Result};
++use async_trait::async_trait;
++use hypervisor::device::device_manager::{do_handle_device, DeviceManager};
++use hypervisor::device::driver::NetworkConfig;
++use hypervisor::device::{DeviceConfig, DeviceType};
++use hypervisor::{Hypervisor, NetworkDevice};
++use tokio::sync::RwLock;
++
++use super::endpoint_persist::{EndpointState, NetkitEndpointState};
++use super::Endpoint;
++use crate::network::{utils, NetworkPair};
++
++#[derive(Debug)]
++pub struct NetkitEndpoint {
++    pub(crate) net_pair: NetworkPair,
++    pub(crate) d: Arc<RwLock<DeviceManager>>,
++}
++
++impl NetkitEndpoint {
++    pub async fn new(
++        d: &Arc<RwLock<DeviceManager>>,
++        handle: &rtnetlink::Handle,
++        name: &str,
++        idx: u32,
++        model: &str,
++        queues: usize,
++    ) -> Result<Self> {
++        let net_pair = NetworkPair::new(handle, idx, name, model, queues)
++            .await
++            .context("new network interface pair failed.")?;
++
++        Ok(NetkitEndpoint {
++            net_pair,
++            d: d.clone(),
++        })
++    }
++
++    fn get_network_config(&self) -> Result<NetworkConfig> {
++        let iface = &self.net_pair.tap.tap_iface;
++        let guest_mac = utils::parse_mac(&iface.hard_addr).ok_or_else(|| {
++            Error::new(
++                io::ErrorKind::InvalidData,
++                format!("hard_addr {}", &iface.hard_addr),
++            )
++        })?;
++
++        Ok(NetworkConfig {
++            host_dev_name: iface.name.clone(),
++            virt_iface_name: self.net_pair.virt_iface.name.clone(),
++            guest_mac: Some(guest_mac),
++            ..Default::default()
++        })
++    }
++}
++
++#[async_trait]
++impl Endpoint for NetkitEndpoint {
++    async fn name(&self) -> String {
++        self.net_pair.virt_iface.name.clone()
++    }
++
++    async fn hardware_addr(&self) -> String {
++        self.net_pair.tap.tap_iface.hard_addr.clone()
++    }
++
++    async fn attach(&self) -> Result<()> {
++        self.net_pair
++            .add_network_model()
++            .await
++            .context("add network model")?;
++
++        let config = self.get_network_config().context("get network config")?;
++        do_handle_device(&self.d, &DeviceConfig::NetworkCfg(config))
++            .await
++            .context("do handle network netkit endpoint device failed.")?;
++
++        Ok(())
++    }
++
++    async fn detach(&self, h: &dyn Hypervisor) -> Result<()> {
++        self.net_pair
++            .del_network_model()
++            .await
++            .context("del network model failed.")?;
++
++        let config = self.get_network_config().context("get network config")?;
++        h.remove_device(DeviceType::Network(NetworkDevice {
++            config,
++            ..Default::default()
++        }))
++        .await
++        .context("remove netkit endpoint device by hypervisor failed.")?;
++
++        Ok(())
++    }
++
++    async fn save(&self) -> Option<EndpointState> {
++        Some(EndpointState {
++            netkit_endpoint: Some(NetkitEndpointState {
++                if_name: self.net_pair.virt_iface.name.clone(),
++                network_qos: self.net_pair.network_qos,
++            }),
++            ..Default::default()
++        })
++    }
++}
+diff --git a/src/runtime-rs/crates/resource/src/network/network_with_netns.rs b/src/runtime-rs/crates/resource/src/network/network_with_netns.rs
+index 817387196..be88c48d0 100644
+--- a/src/runtime-rs/crates/resource/src/network/network_with_netns.rs
++++ b/src/runtime-rs/crates/resource/src/network/network_with_netns.rs
+@@ -24,7 +24,8 @@ use tokio::sync::RwLock;
+ 
+ use super::{
+     endpoint::{
+-        Endpoint, IPVlanEndpoint, MacVlanEndpoint, PhysicalEndpoint, VethEndpoint, VlanEndpoint,
++        Endpoint, IPVlanEndpoint, MacVlanEndpoint, NetkitEndpoint, PhysicalEndpoint, VethEndpoint,
++        VlanEndpoint,
+     },
+     network_entity::NetworkEntity,
+     network_info::network_info_from_link::{handle_addresses, NetworkInfoFromLink},
+@@ -312,6 +313,26 @@ async fn create_endpoint(
+                 .context("macvlan endpoint")?;
+                 Arc::new(ret)
+             }
++            "netkit" => {
++                // L3 mode netkit devices have no MAC address and are not supported.
++                if attrs.hardware_addr.is_empty() {
++                    return Err(anyhow!(
++                        "netkit device {} has no MAC address (L3 mode not supported - use L2 mode or veth)",
++                        attrs.name
++                    ));
++                }
++                let ret = NetkitEndpoint::new(
++                    &d,
++                    handle,
++                    &attrs.name,
++                    idx,
++                    &config.network_model,
++                    config.queues,
++                )
++                .await
++                .context("netkit endpoint")?;
++                Arc::new(ret)
++            }
+             _ => return Err(anyhow!("unsupported link type: {}", link_type)),
+         }
+     };
+diff --git a/src/runtime-rs/crates/resource/src/network/utils/link/manager.rs b/src/runtime-rs/crates/resource/src/network/utils/link/manager.rs
+index fb0365877..ea885f9d4 100644
+--- a/src/runtime-rs/crates/resource/src/network/utils/link/manager.rs
++++ b/src/runtime-rs/crates/resource/src/network/utils/link/manager.rs
+@@ -120,6 +120,11 @@ fn link_info(mut infos: Vec<LinkInfo>) -> Box<dyn Link> {
+                         link = Some(Box::new(Bridge::default()));
+                     }
+                 }
++                InfoKind::Netkit => {
++                    if link.is_none() {
++                        link = Some(Box::new(Netkit::default()));
++                    }
++                }
+                 _ => {
+                     if link.is_none() {
+                         link = Some(Box::new(Device::default()));
+@@ -145,6 +150,9 @@ fn link_info(mut infos: Vec<LinkInfo>) -> Box<dyn Link> {
+                 InfoData::Bridge(ibs) => {
+                     link = Some(Box::new(parse_bridge(ibs)));
+                 }
++                InfoData::Netkit(_) => {
++                    link = Some(Box::new(Netkit::default()));
++                }
+                 _ => {
+                     link = Some(Box::new(Device::default()));
+                 }
+@@ -214,6 +222,7 @@ macro_rules! define_and_impl_network_dev {
+ define_and_impl_network_dev!("device", Device);
+ define_and_impl_network_dev!("tuntap", Tuntap);
+ define_and_impl_network_dev!("veth", Veth);
++define_and_impl_network_dev!("netkit", Netkit);
+ define_and_impl_network_dev!("ipvlan", IpVlan);
+ define_and_impl_network_dev!("macvlan", MacVlan);
+ define_and_impl_network_dev!("vlan", Vlan);
+-- 
+2.54.0
+

--- a/patches/global/0013-datadog-runtime-rs-store-netkit-mode-from-InfoData-a.patch
+++ b/patches/global/0013-datadog-runtime-rs-store-netkit-mode-from-InfoData-a.patch
@@ -1,0 +1,132 @@
+From ddcfa1b17091e24e9e352acb71b575efd5d667a7 Mon Sep 17 00:00:00 2001
+From: Mateo Lelong <mateo.lelong@datadoghq.com>
+Date: Mon, 13 Apr 2026 17:52:55 +0200
+Subject: [PATCH] [datadog] runtime-rs: store netkit mode from InfoData and use
+ it for L3 detection
+
+Signed-off-by: Mateo Lelong <mateo.lelong@datadoghq.com>
+---
+ .../src/network/network_with_netns.rs         | 18 ++++++++++--
+ .../src/network/utils/link/manager.rs         | 28 ++++++++++++++++---
+ .../resource/src/network/utils/link/mod.rs    |  3 +-
+ 3 files changed, 41 insertions(+), 8 deletions(-)
+
+diff --git a/src/runtime-rs/crates/resource/src/network/network_with_netns.rs b/src/runtime-rs/crates/resource/src/network/network_with_netns.rs
+index be88c48d0..2eed69fce 100644
+--- a/src/runtime-rs/crates/resource/src/network/network_with_netns.rs
++++ b/src/runtime-rs/crates/resource/src/network/network_with_netns.rs
+@@ -314,10 +314,22 @@ async fn create_endpoint(
+                 Arc::new(ret)
+             }
+             "netkit" => {
+-                // L3 mode netkit devices have no MAC address and are not supported.
+-                if attrs.hardware_addr.is_empty() {
++                let is_l3 = link
++                    .as_any()
++                    .downcast_ref::<link::Netkit>()
++                    .and_then(|n| n.mode)
++                    .map_or_else(
++                        || {
++                            attrs.hardware_addr.is_empty()
++                            // L3 devices have no MAC address, so check for all-zero.
++                            // https://github.com/torvalds/linux/blob/master/drivers/net/netkit.c
++                                || attrs.hardware_addr.iter().all(|&b| b == 0)
++                        },
++                        |m| m == netlink_packet_route::link::NetkitMode::L3,
++                    );
++                if is_l3 {
+                     return Err(anyhow!(
+-                        "netkit device {} has no MAC address (L3 mode not supported - use L2 mode or veth)",
++                        "netkit device {} is in L3 mode (not supported - use L2 mode or veth)",
+                         attrs.name
+                     ));
+                 }
+diff --git a/src/runtime-rs/crates/resource/src/network/utils/link/manager.rs b/src/runtime-rs/crates/resource/src/network/utils/link/manager.rs
+index ea885f9d4..88cdf4828 100644
+--- a/src/runtime-rs/crates/resource/src/network/utils/link/manager.rs
++++ b/src/runtime-rs/crates/resource/src/network/utils/link/manager.rs
+@@ -5,7 +5,7 @@
+ //
+ 
+ use netlink_packet_route::link::{
+-    InfoBridge, InfoData, InfoKind, LinkAttribute, LinkInfo, LinkMessage,
++    InfoBridge, InfoData, InfoKind, InfoNetkit, LinkAttribute, LinkInfo, LinkMessage, NetkitMode,
+ };
+ 
+ use super::{Link, LinkAttrs};
+@@ -150,8 +150,8 @@ fn link_info(mut infos: Vec<LinkInfo>) -> Box<dyn Link> {
+                 InfoData::Bridge(ibs) => {
+                     link = Some(Box::new(parse_bridge(ibs)));
+                 }
+-                InfoData::Netkit(_) => {
+-                    link = Some(Box::new(Netkit::default()));
++                InfoData::Netkit(nks) => {
++                    link = Some(Box::new(parse_netkit(nks)));
+                 }
+                 _ => {
+                     link = Some(Box::new(Device::default()));
+@@ -173,6 +173,17 @@ fn link_info(mut infos: Vec<LinkInfo>) -> Box<dyn Link> {
+     link.unwrap()
+ }
+ 
++fn parse_netkit(infos: Vec<InfoNetkit>) -> Netkit {
++    let mut netkit = Netkit::default();
++    for info in infos {
++        if let InfoNetkit::Mode(mode) = info {
++            netkit.mode = Some(mode);
++            break;
++        }
++    }
++    netkit
++}
++
+ fn parse_bridge(mut ibs: Vec<InfoBridge>) -> Bridge {
+     let mut bridge = Bridge::default();
+     while let Some(ib) = ibs.pop() {
+@@ -204,6 +215,9 @@ macro_rules! impl_network_dev {
+             fn r#type(&self) -> &'static str {
+                 $r_type
+             }
++            fn as_any(&self) -> &dyn std::any::Any {
++                self
++            }
+         }
+     };
+ }
+@@ -222,7 +236,13 @@ macro_rules! define_and_impl_network_dev {
+ define_and_impl_network_dev!("device", Device);
+ define_and_impl_network_dev!("tuntap", Tuntap);
+ define_and_impl_network_dev!("veth", Veth);
+-define_and_impl_network_dev!("netkit", Netkit);
++#[derive(Debug, PartialEq, Eq, Clone, Default)]
++pub struct Netkit {
++    attrs: Option<LinkAttrs>,
++    pub mode: Option<NetkitMode>,
++}
++
++impl_network_dev!("netkit", Netkit);
+ define_and_impl_network_dev!("ipvlan", IpVlan);
+ define_and_impl_network_dev!("macvlan", MacVlan);
+ define_and_impl_network_dev!("vlan", Vlan);
+diff --git a/src/runtime-rs/crates/resource/src/network/utils/link/mod.rs b/src/runtime-rs/crates/resource/src/network/utils/link/mod.rs
+index 86027f2fe..5e02dc14c 100644
+--- a/src/runtime-rs/crates/resource/src/network/utils/link/mod.rs
++++ b/src/runtime-rs/crates/resource/src/network/utils/link/mod.rs
+@@ -10,7 +10,7 @@ mod driver_info;
+ pub use driver_info::get_driver_info;
+ mod macros;
+ mod manager;
+-pub use manager::get_link_from_message;
++pub use manager::{get_link_from_message, Netkit};
+ 
+ use std::os::unix::io::RawFd;
+ 
+@@ -145,4 +145,5 @@ pub trait Link: Send + Sync {
+     fn attrs(&self) -> &LinkAttrs;
+     fn set_attrs(&mut self, attr: LinkAttrs);
+     fn r#type(&self) -> &str;
++    fn as_any(&self) -> &dyn std::any::Any;
+ }
+-- 
+2.54.0
+


### PR DESCRIPTION
## upstream-chaser conflict

**Tag:** 3.32.0
**Branch:** 3.32.0-mj
**Patch:** /Users/michal.jankowski/go/src/github.com/DataDog/kata-containers/patches/global/0005-datadog-shim-sandbox-size-based-on-cpu-shares.patch

### What happened

`upstream-chaser` could not apply this patch cleanly via `git am --3way`.
The head branch contains a partial application via `git apply --reject --3way` so
you can see which changes applied and which were rejected (.rej files).

### To resolve

1. Check out the head branch locally.
2. Apply the rejected hunks by hand (see .rej files).
3. Remove all .rej files.
4. Commit your changes (one or more commits) and merge this PR.

`upstream-chaser` will extract your commit(s) as a replacement .patch file
on its next run and rebuild the branch automatically.

### Conflict details

```
error: Failed to merge in the changes.
hint: Use 'git am --show-current-patch=diff' to see the failed patch
hint: When you have resolved this problem, run "git am --continue".
hint: If you prefer to skip this patch, run "git am --skip" instead.
hint: To restore the original branch and stop patching, run "git am --abort".
hint: Disable this message with "git config set advice.mergeConflict false"
```

<!-- upstream-chaser-meta
wip-sha: caf7decfd4a655ef1c38cdbd1396e8ebcca0dea4
original-folder: /Users/michal.jankowski/go/src/github.com/DataDog/kata-containers/patches/global
original-file: 0005-datadog-shim-sandbox-size-based-on-cpu-shares.patch
-->
