### PR TITLE
[datadog] ci: publish consolidated kernel .config as build artifact

### DIFF
--- a/.github/workflows/build-kata-os.yml
+++ b/.github/workflows/build-kata-os.yml
@@ -58,11 +58,12 @@ jobs:
           else
             cp tools/packaging/kernel/kata-linux-*/arch/arm64/boot/Image.gz /tmp/vmlinux
           fi
+          cp tools/packaging/kernel/kata-linux-*/.config /tmp/kernel-config
           cp tools/osbuilder/kata-containers-image-ubuntu.img /tmp/kata-containers-image-ubuntu.img
           cp sbom.cdx.gz /tmp/sbom.cdx.gz
           cp src/runtime/containerd-shim-kata-v2 /tmp/containerd-shim-kata-v2
           mkdir -p /tmp/artifacts
-          zip -j /tmp/artifacts/artifacts-${{ matrix.arch }}.zip /tmp/vmlinux /tmp/kata-containers-image-ubuntu.img /tmp/sbom.cdx.gz /tmp/containerd-shim-kata-v2 /tmp/containerd-shim-kata-v2-rs
+          zip -j /tmp/artifacts/artifacts-${{ matrix.arch }}.zip /tmp/vmlinux /tmp/kernel-config /tmp/kata-containers-image-ubuntu.img /tmp/sbom.cdx.gz /tmp/containerd-shim-kata-v2 /tmp/containerd-shim-kata-v2-rs
           cd /tmp/artifacts
           sha256sum artifacts-${{ matrix.arch }}.zip > checksum-${{ matrix.arch }}.sha256
       - name: Upload Artifact

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -36,9 +36,11 @@ build-kernel-amd64:
     - ./build-kernel.sh -v $KERNEL_VERSION setup
     - ./build-kernel.sh -v $KERNEL_VERSION build
     - cp kata-linux-*/arch/x86_64/boot/bzImage ./vmlinux-amd64
+    - cp kata-linux-*/.config ./kernel-config-amd64
   artifacts:
     paths:
       - tools/packaging/kernel/vmlinux-amd64
+      - tools/packaging/kernel/kernel-config-amd64
     expire_in: 1 week
 
 build-kernel-arm64:
@@ -50,9 +52,11 @@ build-kernel-arm64:
     - ./build-kernel.sh -v $KERNEL_VERSION setup
     - ./build-kernel.sh -v $KERNEL_VERSION build
     - cp kata-linux-*/arch/arm64/boot/Image.gz ./vmlinux-arm64
+    - cp kata-linux-*/.config ./kernel-config-arm64
   artifacts:
     paths:
       - tools/packaging/kernel/vmlinux-arm64
+      - tools/packaging/kernel/kernel-config-arm64
     expire_in: 1 week
 
 build-shim-amd64:
@@ -137,6 +141,8 @@ publish-artifacts:
   script:
     - aws s3 cp tools/packaging/kernel/vmlinux-amd64 s3://kata-containers-ci-artifacts/$CI_COMMIT_REF_NAME/amd64/vmlinux
     - aws s3 cp tools/packaging/kernel/vmlinux-arm64 s3://kata-containers-ci-artifacts/$CI_COMMIT_REF_NAME/arm64/vmlinux
+    - aws s3 cp tools/packaging/kernel/kernel-config-amd64 s3://kata-containers-ci-artifacts/$CI_COMMIT_REF_NAME/amd64/kernel-config
+    - aws s3 cp tools/packaging/kernel/kernel-config-arm64 s3://kata-containers-ci-artifacts/$CI_COMMIT_REF_NAME/arm64/kernel-config
     - aws s3 cp src/runtime-rs/containerd-shim-kata-v2-rust-amd64 s3://kata-containers-ci-artifacts/$CI_COMMIT_REF_NAME/amd64/containerd-shim-kata-v2
     - aws s3 cp src/runtime-rs/containerd-shim-kata-v2-rust-arm64 s3://kata-containers-ci-artifacts/$CI_COMMIT_REF_NAME/arm64/containerd-shim-kata-v2
     - echo $CI_COMMIT_REF_NAME > LATEST && aws s3 cp LATEST s3://kata-containers-ci-artifacts/LATEST

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -18,9 +18,12 @@ stages:
 ci-image:
   stage: ci-image
   extends: .build-docker-image
-  when: manual
-  only:
-    - branches
+  # NOTE: .build-docker-image (compute-delivery/v3 template) defines `rules`,
+  # which cannot be mixed with `only`. Express the branches-only-manual intent
+  # via `rules` to keep the merged job config valid.
+  rules:
+    - if: $CI_COMMIT_BRANCH
+      when: manual
   variables:
     IMAGE_NAME: "$CI_PROJECT_NAME/ci"
     IMAGE_TAG: $CI_IMAGE


### PR DESCRIPTION
The merged kernel config is generated during 'build-kernel.sh setup' and only survives in the running kernel via /proc/config.gz. Persisting it as a CI artifact (and to S3 in publish-artifacts) lets us inspect and diff the exact CONFIG_* set a kernel was built with — e.g. to catch a regression like CONFIG_BLK_DEV_NBD flipping between builds — without booting a sandbox.