### PR TITLE
virtcontainers: add tapnet and none internetworking models for host-side proxy

### DIFF
--- a/docs/design/architecture/networking.md
+++ b/docs/design/architecture/networking.md
@@ -36,7 +36,7 @@ compatibility, and performance on par with MACVTAP.
 Kata Containers has deprecated support for bridge due to lacking performance relative to TC-filter and MACVTAP.
 
 For routing all VM traffic through a host-side proxy container instead of the normal
-container network path, see `none` and `tapnet` in
+container network path, see `jailnet` and `tapnet` in
 [how-to-use-host-side-proxy-networking.md](../../how-to/how-to-use-host-side-proxy-networking.md).
 
 Kata Containers supports both

--- a/docs/design/architecture/networking.md
+++ b/docs/design/architecture/networking.md
@@ -35,6 +35,10 @@ compatibility, and performance on par with MACVTAP.
 
 Kata Containers has deprecated support for bridge due to lacking performance relative to TC-filter and MACVTAP.
 
+For routing all VM traffic through a host-side proxy container instead of the normal
+container network path, see `none` and `tapnet` in
+[how-to-use-host-side-proxy-networking.md](../../how-to/how-to-use-host-side-proxy-networking.md).
+
 Kata Containers supports both
 [CNM](https://github.com/moby/libnetwork/blob/master/docs/design.md#the-container-network-model)
 and [CNI](https://github.com/containernetworking/cni) for networking management.

--- a/docs/how-to/README.md
+++ b/docs/how-to/README.md
@@ -36,7 +36,7 @@
 - [How to load kernel modules in Kata Containers](how-to-load-kernel-modules-with-kata.md)
 - [How to use Kata Containers with `virtio-mem`](how-to-use-virtio-mem-with-kata.md)
 - [How to set sandbox Kata Containers configurations with pod annotations](how-to-set-sandbox-config-kata.md)
-- [How to use host-side-proxy networking (`none` and `tapnet`)](how-to-use-host-side-proxy-networking.md)
+- [How to use host-side-proxy networking (`jailnet` and `tapnet`)](how-to-use-host-side-proxy-networking.md)
 - [How to monitor Kata Containers in K8s](how-to-set-prometheus-in-k8s.md)
 - [How to use hotplug memory on arm64 in Kata Containers](how-to-hotplug-memory-arm64.md)
 - [How to setup swap devices in guest kernel](how-to-setup-swap-devices-in-guest-kernel.md)

--- a/docs/how-to/README.md
+++ b/docs/how-to/README.md
@@ -36,6 +36,7 @@
 - [How to load kernel modules in Kata Containers](how-to-load-kernel-modules-with-kata.md)
 - [How to use Kata Containers with `virtio-mem`](how-to-use-virtio-mem-with-kata.md)
 - [How to set sandbox Kata Containers configurations with pod annotations](how-to-set-sandbox-config-kata.md)
+- [How to use host-side-proxy networking (`none` and `tapnet`)](how-to-use-host-side-proxy-networking.md)
 - [How to monitor Kata Containers in K8s](how-to-set-prometheus-in-k8s.md)
 - [How to use hotplug memory on arm64 in Kata Containers](how-to-hotplug-memory-arm64.md)
 - [How to setup swap devices in guest kernel](how-to-setup-swap-devices-in-guest-kernel.md)

--- a/docs/how-to/how-to-set-sandbox-config-kata.md
+++ b/docs/how-to/how-to-set-sandbox-config-kata.md
@@ -27,7 +27,7 @@ There are several kinds of Kata configurations and they are listed below.
 | `io.katacontainers.config.runtime.experimental` | `boolean` | determines if experimental features enabled |
 | `io.katacontainers.config.runtime.disable_guest_seccomp`| `boolean` | determines if `seccomp` should be applied inside guest |
 | `io.katacontainers.config.runtime.disable_new_netns` | `boolean` | determines if a new netns is created for the hypervisor process |
-| `io.katacontainers.config.runtime.internetworking_model` | string| determines how the VM should be connected to the container network interface. Valid values are `macvtap`, `tcfilter`, `none` and `tapnet` |
+| `io.katacontainers.config.runtime.internetworking_model` | string| determines how the VM should be connected to the container network interface. Valid values are `macvtap`, `tcfilter`, `none`, `jailnet` and `tapnet` |
 | `io.katacontainers.config.runtime.sandbox_cgroup_only`| `boolean` | determines if Kata processes are managed only in sandbox cgroup |
 | `io.katacontainers.config.runtime.enable_pprof` | `boolean` | enables Golang `pprof` for `containerd-shim-kata-v2` process |
 | `io.katacontainers.config.runtime.create_container_timeout` | `uint64` | the timeout for create a container in `seconds`, default is `60` |

--- a/docs/how-to/how-to-set-sandbox-config-kata.md
+++ b/docs/how-to/how-to-set-sandbox-config-kata.md
@@ -27,7 +27,7 @@ There are several kinds of Kata configurations and they are listed below.
 | `io.katacontainers.config.runtime.experimental` | `boolean` | determines if experimental features enabled |
 | `io.katacontainers.config.runtime.disable_guest_seccomp`| `boolean` | determines if `seccomp` should be applied inside guest |
 | `io.katacontainers.config.runtime.disable_new_netns` | `boolean` | determines if a new netns is created for the hypervisor process |
-| `io.katacontainers.config.runtime.internetworking_model` | string| determines how the VM should be connected to the container network interface. Valid values are `macvtap`, `tcfilter` and `none` |
+| `io.katacontainers.config.runtime.internetworking_model` | string| determines how the VM should be connected to the container network interface. Valid values are `macvtap`, `tcfilter`, `none` and `tapnet` |
 | `io.katacontainers.config.runtime.sandbox_cgroup_only`| `boolean` | determines if Kata processes are managed only in sandbox cgroup |
 | `io.katacontainers.config.runtime.enable_pprof` | `boolean` | enables Golang `pprof` for `containerd-shim-kata-v2` process |
 | `io.katacontainers.config.runtime.create_container_timeout` | `uint64` | the timeout for create a container in `seconds`, default is `60` |

--- a/docs/how-to/how-to-use-host-side-proxy-networking.md
+++ b/docs/how-to/how-to-use-host-side-proxy-networking.md
@@ -206,25 +206,19 @@ delivered to the guest the same way.
 
 ## Discovery
 
-**Current limitation**: the `<id>` component of both the jail netns name
-(`kata-jail-<id>`) and the tapnet control socket path (`/run/kata-tapnet/<id>.ctrl`) is a
-fresh random UUID generated internally by the shim for each network interface
-(`NetworkInterfacePair.ID`, set in `createNetworkInterfacePair`) — it is **not** derived from
-the sandbox/pod ID and cannot be predicted or computed by an external proxy ahead of time.
-This was a deliberate fix for a cross-sandbox collision bug (an earlier version used the
-per-sandbox-but-not-globally-unique tap interface name, e.g. `tap0_kata`, which collided
-between sandboxes), but it means a proxy needs its own way to find the right path:
+The `<id>` component of both the jail netns name (`kata-jail-<id>`) and the tapnet control
+socket path (`/run/kata-tapnet/<id>.ctrl`) is `<sandbox ID>-<interface index>` — set in
+`addSingleEndpoint` from the sandbox's CRI/OCI ID (the same one visible via `crictl pods`),
+not a randomly generated value. This keeps the name globally unique (fixing an earlier bug
+where both were keyed on the per-sandbox-but-not-globally-unique tap interface name, e.g.
+`tap0_kata`, which collided between sandboxes) while staying computable by anything that
+already knows the pod's sandbox ID — in particular, whatever orchestrates the proxy sidecar
+can pass it the sandbox ID (e.g. via the Kubernetes downward API) and it can compute
+`/run/kata-tapnet/<sandboxID>-0.ctrl` directly, without needing to glob the directory.
 
-- For `tapnet`, a proxy sidecar can glob `/run/kata-tapnet/*.ctrl` if that directory is
-  bind-mounted read-only into the pod (there will typically be exactly one entry per pod
-  unless multiple Kata sandboxes share a host mount).
-- For `none`, the proxy already needs to be running inside the pod's own network namespace
-  to install iptables rules, so it does not need to locate the jail netns by name — only
-  Kata itself does (`removeNoneNetworking`'s teardown path).
-
-If your deployment needs a deterministic path (e.g. to avoid globbing), that would require
-plumbing the sandbox ID down through `xConnectVMNetwork`/`setupTapnetNetworking` — the
-`Endpoint` interface does not currently expose it at that call site.
+`-0` is the index of the pod's first (and for a typical single-NIC pod, only) network
+interface; a second interface on the same sandbox would be `-1`, and so on, matching the
+order interfaces are attached in.
 
 ## Limitations
 

--- a/docs/how-to/how-to-use-host-side-proxy-networking.md
+++ b/docs/how-to/how-to-use-host-side-proxy-networking.md
@@ -1,4 +1,4 @@
-# How to use host-side-proxy networking (`none` and `tapnet`)
+# How to use host-side-proxy networking (`jailnet` and `tapnet`)
 
 This document covers two `internetworking_model` options built for a specific use case:
 routing **all** VM network traffic through a proxy container running alongside the Kata
@@ -7,7 +7,7 @@ bridge the pod's own network interface into the VM).
 
 They are two independent, selectable implementations of the same goal — pick one, not both:
 
-| | `none` | `tapnet` |
+| | `jailnet` | `tapnet` |
 |---|---|---|
 | Mechanism | Kernel tap device in an isolated "jail" netns, bridged to the pod netns via a veth pair, with iptables `REDIRECT` rules | VM's virtio-net device backed directly by a Unix socketpair; no kernel tap device at all |
 | What reaches the proxy | Only TCP and UDP/53 (DNS) — other protocols are dropped by the pod netns's default `FORWARD` policy, not proxied | Everything — the proxy's user-space network stack sees every VM frame (TCP/UDP/ICMP) |
@@ -17,7 +17,7 @@ They are two independent, selectable implementations of the same goal — pick o
 
 If you need maximum protocol coverage and a hard "no bypass" guarantee, use `tapnet`. If you
 need the performance characteristics of a real kernel tap device and can tolerate only
-TCP/DNS being interceptable, use `none`.
+TCP/DNS being interceptable, use `jailnet`.
 
 Both share the same VM-side addressing: the VM is configured with `169.254.1.2/30` and a
 default route via `169.254.1.1`, where the host-side proxy acts as gateway
@@ -31,7 +31,7 @@ Set `internetworking_model` under `[hypervisor.qemu]` in your `configuration.tom
 
 ```toml
 [hypervisor.qemu]
-internetworking_model = "tapnet"   # or "none"
+internetworking_model = "tapnet"   # or "jailnet"
 ```
 
 Or per-pod via the OCI/CRI annotation (see
@@ -43,14 +43,14 @@ annotations:
 ```
 
 Both models also support `disable_new_netns = true` (the runtime accepts this only for
-`none`/`tapnet` — see `checkNetNsConfig` in `src/runtime/pkg/katautils/config.go`).
+`jailnet`/`tapnet` — see `checkNetNsConfig` in `src/runtime/pkg/katautils/config.go`).
 
 In both cases, **a proxy container or process must exist and be reachable from the pod
 before the VM's network traffic is expected to flow.** Kata itself does not run the proxy —
 that's the responsibility of whatever deploys the sandbox (e.g. a sidecar container or
 DaemonSet-installed component).
 
-## `none`: jail netns + veth + iptables REDIRECT
+## `jailnet`: jail netns + veth + iptables REDIRECT
 
 ### Topology
 
@@ -60,7 +60,7 @@ jail netns:  tap0_kata (169.254.1.1/30) ─── kata-pvj (169.254.2.1/30)
 pod  netns:                               kata-pvp (169.254.2.2/30) ─── eth0
 ```
 
-`setupNoneNetworking` (in `network_linux.go`) creates a network namespace named
+`setupJailNetNetworking` (in `network_linux.go`) creates a network namespace named
 `kata-jail-<id>` (bind-mounted at `/run/netns/kata-jail-<id>`) containing only the VM's tap
 device, then bridges it to the pod netns with a veth pair (`kata-pvj` inside the jail,
 `kata-pvp` in the pod netns). `<id>` is the sandbox's per-interface UUID
@@ -222,7 +222,7 @@ order interfaces are attached in.
 
 ## Limitations
 
-- `none` only proxies TCP and UDP/53; every other protocol is dropped, not forwarded.
+- `jailnet` only proxies TCP and UDP/53; every other protocol is dropped, not forwarded.
 - `tapnet` does not support proxy reconnection — a proxy crash or restart requires the pod
   to be restarted to get a new socketpair.
 - Both require an external proxy component; neither is useful on its own.

--- a/docs/how-to/how-to-use-host-side-proxy-networking.md
+++ b/docs/how-to/how-to-use-host-side-proxy-networking.md
@@ -1,0 +1,235 @@
+# How to use host-side-proxy networking (`none` and `tapnet`)
+
+This document covers two `internetworking_model` options built for a specific use case:
+routing **all** VM network traffic through a proxy container running alongside the Kata
+sandbox, instead of Kata's normal container-network path (`tcfilter`/`macvtap`, which simply
+bridge the pod's own network interface into the VM).
+
+They are two independent, selectable implementations of the same goal — pick one, not both:
+
+| | `none` | `tapnet` |
+|---|---|---|
+| Mechanism | Kernel tap device in an isolated "jail" netns, bridged to the pod netns via a veth pair, with iptables `REDIRECT` rules | VM's virtio-net device backed directly by a Unix socketpair; no kernel tap device at all |
+| What reaches the proxy | Only TCP and UDP/53 (DNS) — other protocols are dropped by the pod netns's default `FORWARD` policy, not proxied | Everything — the proxy's user-space network stack sees every VM frame (TCP/UDP/ICMP) |
+| Kernel involvement | Kernel forwards/redirects VM frames up to the interception point (tap + veth are real kernel netdevs — `vhost-net` and multiqueue apply) | None — the kernel never sees a VM frame; QEMU's `-netdev socket,fd=N` reads/writes the socketpair directly |
+| Performance profile | Kernel-level throughput characteristics | User-space stack overhead; the socketpair backend is always single-queue (`mq` is suppressed) |
+| Guarantee | Fails closed for unhandled protocols (dropped) | No protocol is silently dropped, since the proxy sees all of it |
+
+If you need maximum protocol coverage and a hard "no bypass" guarantee, use `tapnet`. If you
+need the performance characteristics of a real kernel tap device and can tolerate only
+TCP/DNS being interceptable, use `none`.
+
+Both share the same VM-side addressing: the VM is configured with `169.254.1.2/30` and a
+default route via `169.254.1.1`, where the host-side proxy acts as gateway
+(`proxyTapVMCIDR`/`proxyTapHostCIDR` in
+`src/runtime/virtcontainers/network_linux.go`).
+
+## Configuring either model
+
+Set `internetworking_model` under `[hypervisor.qemu]` in your `configuration.toml`
+(QEMU-only — this is not implemented for other hypervisor backends):
+
+```toml
+[hypervisor.qemu]
+internetworking_model = "tapnet"   # or "none"
+```
+
+Or per-pod via the OCI/CRI annotation (see
+[how-to-set-sandbox-config-kata.md](how-to-set-sandbox-config-kata.md)):
+
+```yaml
+annotations:
+  io.katacontainers.config.hypervisor.internetworking_model: "tapnet"
+```
+
+Both models also support `disable_new_netns = true` (the runtime accepts this only for
+`none`/`tapnet` — see `checkNetNsConfig` in `src/runtime/pkg/katautils/config.go`).
+
+In both cases, **a proxy container or process must exist and be reachable from the pod
+before the VM's network traffic is expected to flow.** Kata itself does not run the proxy —
+that's the responsibility of whatever deploys the sandbox (e.g. a sidecar container or
+DaemonSet-installed component).
+
+## `none`: jail netns + veth + iptables REDIRECT
+
+### Topology
+
+```
+jail netns:  tap0_kata (169.254.1.1/30) ─── kata-pvj (169.254.2.1/30)
+                                                  │ veth pair
+pod  netns:                               kata-pvp (169.254.2.2/30) ─── eth0
+```
+
+`setupNoneNetworking` (in `network_linux.go`) creates a network namespace named
+`kata-jail-<id>` (bind-mounted at `/run/netns/kata-jail-<id>`) containing only the VM's tap
+device, then bridges it to the pod netns with a veth pair (`kata-pvj` inside the jail,
+`kata-pvp` in the pod netns). `<id>` is the sandbox's per-interface UUID
+(`netPair.ID`), not a predictable name — see [Discovery](#discovery) below for why this
+matters and its current limitation.
+
+### What the proxy must do
+
+The proxy runs **inside the pod netns** (i.e. as a container in the same pod, or otherwise
+joined to that network namespace) and is responsible for:
+
+1. Installing iptables `REDIRECT` rules on `kata-pvp` so that TCP and UDP/53 traffic
+   arriving from the VM is redirected to a local listening port instead of reaching `eth0`.
+2. Accepting the redirected connections and recovering the original destination via
+   `SO_ORIGINAL_DST`, then forwarding to that destination via `eth0`.
+3. Ensuring the pod netns's default `FORWARD` policy is `DROP` — this is what makes
+   "everything else is dropped" a real guarantee rather than an assumption; Kata's shim code
+   does not set this policy itself.
+
+Sketch of the proxy-side setup (illustrative — an iptables library such as
+[`coreos/go-iptables`](https://github.com/coreos/go-iptables) is a reasonable choice in Go):
+
+```go
+const (
+    kataPvp      = "kata-pvp"
+    proxyPort    = 15001 // wherever your proxy listens
+)
+
+func installRedirect(ipt *iptables.IPTables) error {
+    if err := ipt.NewChain("nat", "KATA_PROXY"); err != nil {
+        return err
+    }
+    // Redirect TCP from the VM (arriving on kata-pvp) to the local proxy port.
+    if err := ipt.AppendUnique("nat", "PREROUTING",
+        "-i", kataPvp, "-p", "tcp", "-j", "REDIRECT", "--to-port", fmt.Sprint(proxyPort)); err != nil {
+        return err
+    }
+    // Redirect DNS (UDP/53) the same way.
+    return ipt.AppendUnique("nat", "PREROUTING",
+        "-i", kataPvp, "-p", "udp", "--dport", "53", "-j", "REDIRECT", "--to-port", fmt.Sprint(proxyPort))
+}
+
+func acceptRedirected(lc net.ListenConfig, ctx context.Context) error {
+    ln, err := lc.Listen(ctx, "tcp", fmt.Sprintf(":%d", proxyPort))
+    if err != nil {
+        return err
+    }
+    for {
+        conn, err := ln.Accept()
+        if err != nil {
+            return err
+        }
+        go func(c net.Conn) {
+            defer c.Close()
+            tcpConn := c.(*net.TCPConn)
+            origDst, err := getOriginalDst(tcpConn) // SYS_GETSOCKOPT + SO_ORIGINAL_DST
+            if err != nil {
+                return
+            }
+            upstream, err := net.Dial("tcp", origDst.String())
+            if err != nil {
+                return
+            }
+            defer upstream.Close()
+            go io.Copy(upstream, c)
+            io.Copy(c, upstream)
+        }(conn)
+    }
+}
+```
+
+## `tapnet`: socketpair + user-space stack
+
+### How the handoff works
+
+`setupTapnetNetworking` creates a Unix `socketpair(AF_UNIX, SOCK_STREAM)`. One end
+(`fds[0]`) is passed to QEMU as `-netdev socket,fd=N` — this makes the virtio-net device's
+carrier come up immediately at VM boot, with no dependency on the proxy being ready yet
+(this is what eliminates the boot-race a naive "QEMU listens, proxy dials" design would
+have). The other end (`fds[1]`, the "control" fd) is held by the shim, which:
+
+1. Starts draining it in the background (`drainFile`) so VM TX frames don't fill the
+   socketpair buffer while waiting for a proxy.
+2. Listens on a Unix control socket at `/run/kata-tapnet/<id>.ctrl` (`<id>` again being
+   `netPair.ID`, a per-interface UUID — see [Discovery](#discovery)).
+3. On the first connection to that socket, sends the control fd to the connecting process
+   via `SCM_RIGHTS` (`serveTapnetCtrl` in `network_linux.go`), then exits.
+
+From that point on, the proxy owns the control fd and every byte written to/read from it is
+a raw Ethernet frame from/to the VM's virtio-net device. **Reconnection is not supported**:
+if the proxy exits, QEMU marks the virtio-net link down; a pod restart is required to
+re-establish the socketpair.
+
+### Proxy-side sample code
+
+```go
+// connectToTapnet dials the shim's control socket and receives the VM-facing
+// fd via SCM_RIGHTS, returning it as an *os.File wrapping raw VM frames.
+func connectToTapnet(ctrlPath string) (*os.File, error) {
+    conn, err := net.Dial("unix", ctrlPath)
+    if err != nil {
+        return nil, fmt.Errorf("dial tapnet ctrl socket: %w", err)
+    }
+    defer conn.Close()
+
+    uc := conn.(*net.UnixConn)
+    rawConn, err := uc.SyscallConn()
+    if err != nil {
+        return nil, err
+    }
+
+    buf := make([]byte, 1)
+    oob := make([]byte, unix.CmsgSpace(4)) // room for one fd
+    var n, oobn int
+    var recvErr error
+    if err := rawConn.Read(func(fd uintptr) bool {
+        n, oobn, _, _, recvErr = unix.Recvmsg(int(fd), buf, oob, 0)
+        return true
+    }); err != nil {
+        return nil, err
+    }
+    if recvErr != nil {
+        return nil, fmt.Errorf("recvmsg: %w", recvErr)
+    }
+    scms, err := unix.ParseSocketControlMessage(oob[:oobn])
+    if err != nil || len(scms) == 0 {
+        return nil, fmt.Errorf("no control message received (n=%d)", n)
+    }
+    fds, err := unix.ParseUnixRights(&scms[0])
+    if err != nil || len(fds) == 0 {
+        return nil, fmt.Errorf("no fd in control message")
+    }
+    return os.NewFile(uintptr(fds[0]), "tapnet-vm"), nil
+}
+```
+
+Once you have the `*os.File`, wrap it as a `net.Conn` (or hand its fd to a packet-level
+library) and drive a user-space TCP/IP stack against it — e.g.
+[gVisor's netstack](https://github.com/google/gvisor/tree/master/pkg/tcpip), as used by
+[gvisor-tap-vsock](https://github.com/containers/gvisor-tap-vsock). The frames you read are
+raw Ethernet frames sent by the guest's virtio-net driver; whatever you write back is
+delivered to the guest the same way.
+
+## Discovery
+
+**Current limitation**: the `<id>` component of both the jail netns name
+(`kata-jail-<id>`) and the tapnet control socket path (`/run/kata-tapnet/<id>.ctrl`) is a
+fresh random UUID generated internally by the shim for each network interface
+(`NetworkInterfacePair.ID`, set in `createNetworkInterfacePair`) — it is **not** derived from
+the sandbox/pod ID and cannot be predicted or computed by an external proxy ahead of time.
+This was a deliberate fix for a cross-sandbox collision bug (an earlier version used the
+per-sandbox-but-not-globally-unique tap interface name, e.g. `tap0_kata`, which collided
+between sandboxes), but it means a proxy needs its own way to find the right path:
+
+- For `tapnet`, a proxy sidecar can glob `/run/kata-tapnet/*.ctrl` if that directory is
+  bind-mounted read-only into the pod (there will typically be exactly one entry per pod
+  unless multiple Kata sandboxes share a host mount).
+- For `none`, the proxy already needs to be running inside the pod's own network namespace
+  to install iptables rules, so it does not need to locate the jail netns by name — only
+  Kata itself does (`removeNoneNetworking`'s teardown path).
+
+If your deployment needs a deterministic path (e.g. to avoid globbing), that would require
+plumbing the sandbox ID down through `xConnectVMNetwork`/`setupTapnetNetworking` — the
+`Endpoint` interface does not currently expose it at that call site.
+
+## Limitations
+
+- `none` only proxies TCP and UDP/53; every other protocol is dropped, not forwarded.
+- `tapnet` does not support proxy reconnection — a proxy crash or restart requires the pod
+  to be restarted to get a new socketpair.
+- Both require an external proxy component; neither is useful on its own.
+- Only implemented for the QEMU hypervisor backend.

--- a/docs/how-to/how-to-use-host-side-proxy-networking.md
+++ b/docs/how-to/how-to-use-host-side-proxy-networking.md
@@ -10,14 +10,17 @@ They are two independent, selectable implementations of the same goal — pick o
 | | `jailnet` | `tapnet` |
 |---|---|---|
 | Mechanism | Kernel tap device in an isolated "jail" netns, bridged to the pod netns via a veth pair, with iptables `REDIRECT` rules | VM's virtio-net device backed directly by a Unix socketpair; no kernel tap device at all |
-| What reaches the proxy | Only TCP and UDP/53 (DNS) — other protocols are dropped by the pod netns's default `FORWARD` policy, not proxied | Everything — the proxy's user-space network stack sees every VM frame (TCP/UDP/ICMP) |
+| What reaches the proxy | Only what the proxy's own `REDIRECT` rules match (typically TCP and UDP/53) — everything else is forwarded to `eth0` unmodified *unless the proxy also installs a `FORWARD` drop rule for it* (see [What the proxy must do](#what-the-proxy-must-do)) | Everything — the proxy's user-space network stack sees every VM frame (TCP/UDP/ICMP); there is no separate rule to remember |
 | Kernel involvement | Kernel forwards/redirects VM frames up to the interception point (tap + veth are real kernel netdevs — `vhost-net` and multiqueue apply) | None — the kernel never sees a VM frame; QEMU's `-netdev socket,fd=N` reads/writes the socketpair directly |
 | Performance profile | Kernel-level throughput characteristics | User-space stack overhead; the socketpair backend is always single-queue (`mq` is suppressed) |
-| Guarantee | Fails closed for unhandled protocols (dropped) | No protocol is silently dropped, since the proxy sees all of it |
+| Isolation | Only as strong as the proxy's own iptables rules — Kata does not enforce or verify them | Structural: the kernel never sees a VM frame, so there is nothing for the proxy to forget to configure |
 
-If you need maximum protocol coverage and a hard "no bypass" guarantee, use `tapnet`. If you
-need the performance characteristics of a real kernel tap device and can tolerate only
-TCP/DNS being interceptable, use `jailnet`.
+`tapnet` gives you protocol coverage and a bypass guarantee that holds regardless of the
+proxy's own correctness, at the cost of user-space stack performance. `jailnet` gives you
+kernel-level performance, but "no bypass" is not something Kata provides for you — it is
+entirely the proxy's responsibility to get both the `REDIRECT` rules and the `FORWARD` drop
+rule right (see below). Use `jailnet` if you need the performance and can be confident in
+the proxy's own iptables setup; use `tapnet` if you want that guarantee to not depend on it.
 
 Both share the same VM-side addressing: the VM is configured with `169.254.1.2/30` and a
 default route via `169.254.1.1`, where the host-side proxy acts as gateway
@@ -63,48 +66,66 @@ pod  netns:                               kata-pvp (169.254.2.2/30) ─── et
 `setupJailNetNetworking` (in `network_linux.go`) creates a network namespace named
 `kata-jail-<id>` (bind-mounted at `/run/netns/kata-jail-<id>`) containing only the VM's tap
 device, then bridges it to the pod netns with a veth pair (`kata-pvj` inside the jail,
-`kata-pvp` in the pod netns). `<id>` is the sandbox's per-interface UUID
-(`netPair.ID`), not a predictable name — see [Discovery](#discovery) below for why this
-matters and its current limitation.
+`kata-pvp` in the pod netns). `<id>` is `netPair.ID` — see [Discovery](#discovery) below for
+what it's derived from and why that matters.
 
 ### What the proxy must do
 
 The proxy runs **inside the pod netns** (i.e. as a container in the same pod, or otherwise
-joined to that network namespace) and is responsible for:
+joined to that network namespace) and is responsible for all of the following. The first
+two are what makes traffic reach the proxy at all; the third is what makes everything else
+actually get dropped rather than silently forwarded — **it is easy to build a proxy that
+does the first two and skips the third, and it will look like it's working (TCP and DNS get
+proxied) while every other protocol goes straight to `eth0` unfiltered.** Kata's shim does
+not set this up for you: `setupJailNetNetworking` enables `ip_forward` inside the jail netns
+purely so the kernel is capable of moving packets from the tap onto the veth — that is what
+makes forwarding *possible*, and by itself it does nothing to restrict *what* gets forwarded.
 
-1. Installing iptables `REDIRECT` rules on `kata-pvp` so that TCP and UDP/53 traffic
-   arriving from the VM is redirected to a local listening port instead of reaching `eth0`.
-2. Accepting the redirected connections and recovering the original destination via
-   `SO_ORIGINAL_DST`, then forwarding to that destination via `eth0`.
-3. Ensuring the pod netns's default `FORWARD` policy is `DROP` — this is what makes
-   "everything else is dropped" a real guarantee rather than an assumption; Kata's shim code
-   does not set this policy itself.
+1. Install iptables `REDIRECT` rules on `kata-pvp` so that TCP and UDP/53 traffic arriving
+   from the VM is redirected to a local listening port instead of reaching `eth0`.
+2. Accept the redirected TCP connections (and receive the redirected UDP/53 packets),
+   recover the original destination, and forward accordingly.
+3. **Install a rule that drops everything else reaching the `FORWARD` chain from
+   `kata-pvp`.** `REDIRECT` only diverts what it matches — traffic that misses both rules
+   above is not implicitly blocked, it is forwarded normally like any other packet in the
+   netns unless something explicitly stops it. This rule is that something.
 
-Sketch of the proxy-side setup (illustrative — an iptables library such as
-[`coreos/go-iptables`](https://github.com/coreos/go-iptables) is a reasonable choice in Go):
+Full example (an iptables library such as
+[`coreos/go-iptables`](https://github.com/coreos/go-iptables) is a reasonable choice in Go).
+This is illustrative, not production code — for example, it copies raw UDP payloads without
+DNS-aware parsing/validation, and error handling is trimmed for brevity:
 
 ```go
 const (
     kataPvp      = "kata-pvp"
-    proxyPort    = 15001 // wherever your proxy listens
+    tcpProxyPort = 15001 // wherever your TCP proxy listens
+    dnsProxyPort = 15053 // wherever your DNS proxy listens
+    upstreamDNS  = "8.8.8.8:53"
 )
 
+// installRedirect sets up both interception (steps 1-2) and enforcement
+// (step 3). Do not skip the FORWARD rule at the end — without it this
+// function only implements a transparent proxy, not an isolation boundary.
 func installRedirect(ipt *iptables.IPTables) error {
-    if err := ipt.NewChain("nat", "KATA_PROXY"); err != nil {
-        return err
-    }
-    // Redirect TCP from the VM (arriving on kata-pvp) to the local proxy port.
     if err := ipt.AppendUnique("nat", "PREROUTING",
-        "-i", kataPvp, "-p", "tcp", "-j", "REDIRECT", "--to-port", fmt.Sprint(proxyPort)); err != nil {
+        "-i", kataPvp, "-p", "tcp", "-j", "REDIRECT", "--to-port", fmt.Sprint(tcpProxyPort)); err != nil {
         return err
     }
-    // Redirect DNS (UDP/53) the same way.
-    return ipt.AppendUnique("nat", "PREROUTING",
-        "-i", kataPvp, "-p", "udp", "--dport", "53", "-j", "REDIRECT", "--to-port", fmt.Sprint(proxyPort))
+    if err := ipt.AppendUnique("nat", "PREROUTING",
+        "-i", kataPvp, "-p", "udp", "--dport", "53", "-j", "REDIRECT", "--to-port", fmt.Sprint(dnsProxyPort)); err != nil {
+        return err
+    }
+    // REDIRECTed packets are rewritten to a local destination before the
+    // FORWARD chain is ever evaluated, so neither rule above interacts with
+    // this one. Anything that reaches this rule is, by construction,
+    // traffic that matched neither REDIRECT above — drop it here, or it
+    // goes to eth0 exactly as if this proxy did not exist.
+    return ipt.AppendUnique("filter", "FORWARD", "-i", kataPvp, "-j", "DROP")
 }
 
-func acceptRedirected(lc net.ListenConfig, ctx context.Context) error {
-    ln, err := lc.Listen(ctx, "tcp", fmt.Sprintf(":%d", proxyPort))
+// acceptTCP handles the REDIRECTed TCP traffic (installRedirect rule 1).
+func acceptTCP(ctx context.Context, lc net.ListenConfig) error {
+    ln, err := lc.Listen(ctx, "tcp", fmt.Sprintf(":%d", tcpProxyPort))
     if err != nil {
         return err
     }
@@ -115,8 +136,7 @@ func acceptRedirected(lc net.ListenConfig, ctx context.Context) error {
         }
         go func(c net.Conn) {
             defer c.Close()
-            tcpConn := c.(*net.TCPConn)
-            origDst, err := getOriginalDst(tcpConn) // SYS_GETSOCKOPT + SO_ORIGINAL_DST
+            origDst, err := getOriginalDst(c.(*net.TCPConn))
             if err != nil {
                 return
             }
@@ -128,6 +148,78 @@ func acceptRedirected(lc net.ListenConfig, ctx context.Context) error {
             go io.Copy(upstream, c)
             io.Copy(c, upstream)
         }(conn)
+    }
+}
+
+// soOriginalDst is SO_ORIGINAL_DST from linux/netfilter_ipv4.h — the only
+// way to recover a REDIRECTed connection's pre-rewrite destination; without
+// this, the proxy only ever sees its own listening address on tcpProxyPort.
+const soOriginalDst = 80
+
+func getOriginalDst(conn *net.TCPConn) (*net.TCPAddr, error) {
+    rawConn, err := conn.SyscallConn()
+    if err != nil {
+        return nil, err
+    }
+
+    var addr syscall.RawSockaddrInet4
+    addrLen := uint32(unsafe.Sizeof(addr))
+    var sockErr error
+    if err := rawConn.Control(func(fd uintptr) {
+        _, _, errno := syscall.Syscall6(syscall.SYS_GETSOCKOPT, fd,
+            syscall.IPPROTO_IP, soOriginalDst,
+            uintptr(unsafe.Pointer(&addr)), uintptr(unsafe.Pointer(&addrLen)), 0)
+        if errno != 0 {
+            sockErr = errno
+        }
+    }); err != nil {
+        return nil, err
+    }
+    if sockErr != nil {
+        return nil, fmt.Errorf("getsockopt SO_ORIGINAL_DST: %w", sockErr)
+    }
+
+    ip := net.IPv4(addr.Addr[0], addr.Addr[1], addr.Addr[2], addr.Addr[3])
+    port := int(addr.Port[0])<<8 | int(addr.Port[1]) // network byte order
+    return &net.TCPAddr{IP: ip, Port: port}, nil
+}
+
+// handleDNS handles the REDIRECTed UDP/53 traffic (installRedirect rule 2).
+// Unlike TCP, no SO_ORIGINAL_DST-style recovery is needed for the reply:
+// REDIRECT's conntrack NAT state un-rewrites the source on the way back, so
+// writing to whatever address the query came from is sufficient — the VM
+// sees the reply as if it came from whatever it originally queried.
+func handleDNS(ctx context.Context, lc net.ListenConfig) error {
+    pc, err := lc.ListenPacket(ctx, "udp", fmt.Sprintf(":%d", dnsProxyPort))
+    if err != nil {
+        return err
+    }
+    defer pc.Close()
+
+    buf := make([]byte, 4096)
+    for {
+        n, clientAddr, err := pc.ReadFrom(buf)
+        if err != nil {
+            return err
+        }
+        query := append([]byte(nil), buf[:n]...)
+        go func(query []byte, clientAddr net.Addr) {
+            upstream, err := net.Dial("udp", upstreamDNS)
+            if err != nil {
+                return
+            }
+            defer upstream.Close()
+            upstream.SetDeadline(time.Now().Add(5 * time.Second))
+            if _, err := upstream.Write(query); err != nil {
+                return
+            }
+            resp := make([]byte, 4096)
+            n, err := upstream.Read(resp)
+            if err != nil {
+                return
+            }
+            pc.WriteTo(resp[:n], clientAddr)
+        }(query, clientAddr)
     }
 }
 ```
@@ -145,7 +237,7 @@ have). The other end (`fds[1]`, the "control" fd) is held by the shim, which:
 1. Starts draining it in the background (`drainFile`) so VM TX frames don't fill the
    socketpair buffer while waiting for a proxy.
 2. Listens on a Unix control socket at `/run/kata-tapnet/<id>.ctrl` (`<id>` again being
-   `netPair.ID`, a per-interface UUID — see [Discovery](#discovery)).
+   `netPair.ID` — see [Discovery](#discovery)).
 3. On the first connection to that socket, sends the control fd to the connecting process
    via `SCM_RIGHTS` (`serveTapnetCtrl` in `network_linux.go`), then exits.
 
@@ -222,7 +314,10 @@ order interfaces are attached in.
 
 ## Limitations
 
-- `jailnet` only proxies TCP and UDP/53; every other protocol is dropped, not forwarded.
+- `jailnet` only proxies whatever protocols the proxy's `REDIRECT` rules match (typically TCP
+  and UDP/53), and only *drops* everything else if the proxy also installs the `FORWARD` drop
+  rule described above — Kata does not do either of these for you, and a proxy that skips the
+  drop rule will silently forward unmatched traffic instead of blocking it.
 - `tapnet` does not support proxy reconnection — a proxy crash or restart requires the pod
   to be restarted to get a new socketpair.
 - Both require an external proxy component; neither is useful on its own.

--- a/src/runtime/config/configuration-qemu.toml.in
+++ b/src/runtime/config/configuration-qemu.toml.in
@@ -599,7 +599,18 @@ enable_debug = false
 #     macvtap.
 #
 #   - none
-#     Used when customize network. Only creates a tap device. No veth pair.
+#     For host-side proxy setups. Creates the VM's tap device inside an
+#     isolated jail network namespace, bridged to the pod netns via a veth
+#     pair. A host-side proxy container installs iptables REDIRECT rules to
+#     intercept VM egress; only TCP and UDP/53 are redirected, everything
+#     else is dropped. See docs/how-to/how-to-use-host-side-proxy-networking.md.
+#
+#   - tapnet
+#     For host-side proxy setups. The VM's virtio-net device is backed by a
+#     Unix socketpair instead of a kernel tap device; a host-side proxy
+#     container owns the far end and handles all VM traffic (TCP/UDP/ICMP)
+#     in a user-space network stack. The kernel never sees VM frames.
+#     See docs/how-to/how-to-use-host-side-proxy-networking.md.
 #
 #   - tcfilter
 #     Uses tc filter rules to redirect traffic from the network interface

--- a/src/runtime/config/configuration-qemu.toml.in
+++ b/src/runtime/config/configuration-qemu.toml.in
@@ -599,6 +599,9 @@ enable_debug = false
 #     macvtap.
 #
 #   - none
+#     Used when customize network. Only creates a tap device. No veth pair.
+#
+#   - jailnet
 #     For host-side proxy setups. Creates the VM's tap device inside an
 #     isolated jail network namespace, bridged to the pod netns via a veth
 #     pair. A host-side proxy container installs iptables REDIRECT rules to

--- a/src/runtime/pkg/govmm/qemu/qemu.go
+++ b/src/runtime/pkg/govmm/qemu/qemu.go
@@ -900,6 +900,22 @@ const (
 
 	// VHOSTUSER is a vhost-user port (socket)
 	VHOSTUSER NetDeviceType = "vhostuser"
+
+	// NetDeviceStream is a stream-based networking device using a Unix domain
+	// socket.  Supported from QEMU 7.2+.  Produces:
+	//   -netdev stream,id=<id>,server=on,addr.type=unix,addr.path=<path>
+	// QEMU acts as the server (listens); the proxy dials and calls AcceptQemu.
+	// Uses QEMU's 4-byte big-endian length-prefix framing (QemuProtocol).
+	NetDeviceStream NetDeviceType = "stream"
+
+	// NetDeviceSocketFd is a socket-based networking device using a pre-existing
+	// file descriptor (from a Unix socketpair).  Produces:
+	//   -netdev socket,id=<id>,fd=<N>
+	// Both ends of the socketpair are connected at QEMU launch, so the
+	// virtio-net device always has a live backend — no race between VM boot
+	// and proxy startup.  The shim holds the proxy end and hands it off via
+	// SCM_RIGHTS on a control socket once the proxy container connects.
+	NetDeviceSocketFd NetDeviceType = "socketfd"
 )
 
 // QemuNetdevParam converts to the QEMU -netdev parameter notation
@@ -927,6 +943,10 @@ func (n NetDeviceType) QemuNetdevParam(netdev *NetDevice, config *Config) string
 			log.Fatal("vhost-user devices are not supported on IBM Z")
 		}
 		return "vhost-user" // -netdev type=vhost-user (no device)
+	case NetDeviceStream:
+		return "stream"
+	case NetDeviceSocketFd:
+		return "socket"
 	default:
 		return ""
 
@@ -950,6 +970,10 @@ func (n NetDeviceType) QemuDeviceParam(netdev *NetDevice, config *Config) Device
 		device = "virtio-net"
 	case VETHTAP:
 		device = "virtio-net" // -netdev type=tap -device virtio-net-pci
+	case NetDeviceStream:
+		device = "virtio-net"
+	case NetDeviceSocketFd:
+		device = "virtio-net"
 	case VFIO:
 		if netdev.Transport == TransportMMIO {
 			log.Fatal("vfio devices are not support with the MMIO transport")
@@ -1008,6 +1032,10 @@ type NetDevice struct {
 	FDs      []*os.File
 	VhostFDs []*os.File
 
+	// SocketPath is the Unix socket path for NetDeviceStream.
+	// QEMU creates and listens on this socket (server=on); the proxy dials it.
+	SocketPath string
+
 	// VHost enables virtio device emulation from the host kernel instead of from qemu.
 	VHost bool
 
@@ -1037,15 +1065,19 @@ var VirtioNetTransport = map[VirtioTransport]string{
 
 // Valid returns true if the NetDevice structure is valid and complete.
 func (netdev NetDevice) Valid() bool {
-	if netdev.ID == "" || netdev.IFName == "" {
+	if netdev.ID == "" {
 		return false
 	}
 
 	switch netdev.Type {
 	case TAP:
-		return true
+		return netdev.IFName != ""
 	case MACVTAP:
-		return true
+		return netdev.IFName != ""
+	case NetDeviceStream:
+		return netdev.SocketPath != ""
+	case NetDeviceSocketFd:
+		return len(netdev.FDs) > 0
 	default:
 		return false
 	}
@@ -1107,8 +1139,8 @@ func (netdev NetDevice) QemuDeviceParams(config *Config) []string {
 		deviceParams = append(deviceParams, s)
 	}
 
-	if len(netdev.FDs) > 0 {
-		// Note: We are appending to the device params here
+	// mq is only valid for tap-based netdevs; socket/stream use single-queue.
+	if len(netdev.FDs) > 0 && netdev.Type != NetDeviceSocketFd {
 		deviceParams = append(deviceParams, netdev.mqParameter(config))
 	}
 
@@ -1137,6 +1169,23 @@ func (netdev NetDevice) QemuNetdevParams(config *Config) []string {
 
 	netdevParams = append(netdevParams, netdevType)
 	netdevParams = append(netdevParams, fmt.Sprintf("id=%s", netdev.ID))
+
+	// Stream netdev uses a Unix socket — no fds, vhost, or ifname.
+	if netdev.Type == NetDeviceStream {
+		netdevParams = append(netdevParams, "server=on")
+		netdevParams = append(netdevParams, "addr.type=unix")
+		netdevParams = append(netdevParams, fmt.Sprintf("addr.path=%s", netdev.SocketPath))
+		return netdevParams
+	}
+
+	// SocketFd netdev uses a pre-connected socketpair fd.
+	if netdev.Type == NetDeviceSocketFd {
+		if len(netdev.FDs) > 0 {
+			qemuFDs := config.appendFDs(netdev.FDs)
+			netdevParams = append(netdevParams, fmt.Sprintf("fd=%d", qemuFDs[0]))
+		}
+		return netdevParams
+	}
 
 	if netdev.VHost {
 		netdevParams = append(netdevParams, "vhost=on")

--- a/src/runtime/pkg/govmm/qemu/qemu.go
+++ b/src/runtime/pkg/govmm/qemu/qemu.go
@@ -901,13 +901,6 @@ const (
 	// VHOSTUSER is a vhost-user port (socket)
 	VHOSTUSER NetDeviceType = "vhostuser"
 
-	// NetDeviceStream is a stream-based networking device using a Unix domain
-	// socket.  Supported from QEMU 7.2+.  Produces:
-	//   -netdev stream,id=<id>,server=on,addr.type=unix,addr.path=<path>
-	// QEMU acts as the server (listens); the proxy dials and calls AcceptQemu.
-	// Uses QEMU's 4-byte big-endian length-prefix framing (QemuProtocol).
-	NetDeviceStream NetDeviceType = "stream"
-
 	// NetDeviceSocketFd is a socket-based networking device using a pre-existing
 	// file descriptor (from a Unix socketpair).  Produces:
 	//   -netdev socket,id=<id>,fd=<N>
@@ -943,8 +936,6 @@ func (n NetDeviceType) QemuNetdevParam(netdev *NetDevice, config *Config) string
 			log.Fatal("vhost-user devices are not supported on IBM Z")
 		}
 		return "vhost-user" // -netdev type=vhost-user (no device)
-	case NetDeviceStream:
-		return "stream"
 	case NetDeviceSocketFd:
 		return "socket"
 	default:
@@ -970,8 +961,6 @@ func (n NetDeviceType) QemuDeviceParam(netdev *NetDevice, config *Config) Device
 		device = "virtio-net"
 	case VETHTAP:
 		device = "virtio-net" // -netdev type=tap -device virtio-net-pci
-	case NetDeviceStream:
-		device = "virtio-net"
 	case NetDeviceSocketFd:
 		device = "virtio-net"
 	case VFIO:
@@ -1032,10 +1021,6 @@ type NetDevice struct {
 	FDs      []*os.File
 	VhostFDs []*os.File
 
-	// SocketPath is the Unix socket path for NetDeviceStream.
-	// QEMU creates and listens on this socket (server=on); the proxy dials it.
-	SocketPath string
-
 	// VHost enables virtio device emulation from the host kernel instead of from qemu.
 	VHost bool
 
@@ -1070,12 +1055,8 @@ func (netdev NetDevice) Valid() bool {
 	}
 
 	switch netdev.Type {
-	case TAP:
+	case TAP, MACVTAP:
 		return netdev.IFName != ""
-	case MACVTAP:
-		return netdev.IFName != ""
-	case NetDeviceStream:
-		return netdev.SocketPath != ""
 	case NetDeviceSocketFd:
 		return len(netdev.FDs) > 0
 	default:
@@ -1139,7 +1120,7 @@ func (netdev NetDevice) QemuDeviceParams(config *Config) []string {
 		deviceParams = append(deviceParams, s)
 	}
 
-	// mq is only valid for tap-based netdevs; socket/stream use single-queue.
+	// mq is only valid for tap-based netdevs; the socketfd backend is single-queue.
 	if len(netdev.FDs) > 0 && netdev.Type != NetDeviceSocketFd {
 		deviceParams = append(deviceParams, netdev.mqParameter(config))
 	}
@@ -1170,20 +1151,14 @@ func (netdev NetDevice) QemuNetdevParams(config *Config) []string {
 	netdevParams = append(netdevParams, netdevType)
 	netdevParams = append(netdevParams, fmt.Sprintf("id=%s", netdev.ID))
 
-	// Stream netdev uses a Unix socket — no fds, vhost, or ifname.
-	if netdev.Type == NetDeviceStream {
-		netdevParams = append(netdevParams, "server=on")
-		netdevParams = append(netdevParams, "addr.type=unix")
-		netdevParams = append(netdevParams, fmt.Sprintf("addr.path=%s", netdev.SocketPath))
-		return netdevParams
-	}
-
-	// SocketFd netdev uses a pre-connected socketpair fd.
+	// SocketFd netdev uses a pre-connected socketpair fd. Valid() should have
+	// already rejected a NetDevice with no FDs before it reaches here.
 	if netdev.Type == NetDeviceSocketFd {
-		if len(netdev.FDs) > 0 {
-			qemuFDs := config.appendFDs(netdev.FDs)
-			netdevParams = append(netdevParams, fmt.Sprintf("fd=%d", qemuFDs[0]))
+		if len(netdev.FDs) == 0 {
+			log.Fatal("NetDeviceSocketFd netdev requires at least one FD")
 		}
+		qemuFDs := config.appendFDs(netdev.FDs)
+		netdevParams = append(netdevParams, fmt.Sprintf("fd=%d", qemuFDs[0]))
 		return netdevParams
 	}
 

--- a/src/runtime/pkg/govmm/qemu/qmp.go
+++ b/src/runtime/pkg/govmm/qemu/qmp.go
@@ -1021,6 +1021,19 @@ func (q *QMP) ExecuteNetdevAddByFds(ctx context.Context, netdevType, netdevID st
 	return q.executeCommand(ctx, "netdev_add", args, nil)
 }
 
+// ExecuteNetdevAddBySocketFd adds a socket-backed netdev to a QEMU instance
+// using a single pre-connected fd (e.g. one end of a Unix socketpair).
+// netdevID is the id of the device to add; fdName must already have been
+// passed to QEMU via ExecuteGetFD.
+func (q *QMP) ExecuteNetdevAddBySocketFd(ctx context.Context, netdevID, fdName string) error {
+	args := map[string]interface{}{
+		"type": "socket",
+		"id":   netdevID,
+		"fd":   fdName,
+	}
+	return q.executeCommand(ctx, "netdev_add", args, nil)
+}
+
 // ExecuteNetdevDel deletes a Net device from a QEMU instance
 // using the netdev_del command. netdevID is the id of the device to delete.
 func (q *QMP) ExecuteNetdevDel(ctx context.Context, netdevID string) error {

--- a/src/runtime/pkg/katautils/config.go
+++ b/src/runtime/pkg/katautils/config.go
@@ -2075,8 +2075,9 @@ func checkPCIeConfig(coldPlug config.PCIePort, hotPlug config.PCIePort, machineT
 // Because it is an expert option and conflicts with some other common configs.
 func checkNetNsConfig(config oci.RuntimeConfig) error {
 	if config.DisableNewNetNs {
-		if config.InterNetworkModel != vc.NetXConnectNoneModel {
-			return fmt.Errorf("config disable_new_netns only works with 'none' internetworking_model")
+		if config.InterNetworkModel != vc.NetXConnectNoneModel &&
+			config.InterNetworkModel != vc.NetXConnectNoneTapnetModel {
+			return fmt.Errorf("config disable_new_netns only works with 'none' or 'tapnet' internetworking_model")
 		}
 	}
 

--- a/src/runtime/pkg/katautils/config.go
+++ b/src/runtime/pkg/katautils/config.go
@@ -2076,8 +2076,9 @@ func checkPCIeConfig(coldPlug config.PCIePort, hotPlug config.PCIePort, machineT
 func checkNetNsConfig(config oci.RuntimeConfig) error {
 	if config.DisableNewNetNs {
 		if config.InterNetworkModel != vc.NetXConnectNoneModel &&
+			config.InterNetworkModel != vc.NetXConnectJailNetModel &&
 			config.InterNetworkModel != vc.NetXConnectNoneTapnetModel {
-			return fmt.Errorf("config disable_new_netns only works with 'none' or 'tapnet' internetworking_model")
+			return fmt.Errorf("config disable_new_netns only works with 'none', 'jailnet' or 'tapnet' internetworking_model")
 		}
 	}
 

--- a/src/runtime/virtcontainers/network.go
+++ b/src/runtime/virtcontainers/network.go
@@ -124,6 +124,13 @@ const (
 	// NetXConnectNoneModel can be used when the VM is in the host network namespace
 	NetXConnectNoneModel
 
+	// NetXConnectNoneTapnetModel is like NetXConnectNoneModel but the tap is
+	// created directly in the pod network namespace (no jail netns, no veth).
+	// The host-sidecar proxy opens the tap fd and drives a gvisor-tap-vsock
+	// user-space network stack; no iptables rules are installed by the shim.
+	// Corresponds to internetworking_model=tapnet in configuration.toml.
+	NetXConnectNoneTapnetModel
+
 	// NetXConnectInvalidModel is the last item to Check valid values by IsValid()
 	NetXConnectInvalidModel
 )
@@ -154,6 +161,8 @@ func (n *NetInterworkingModel) GetModel() string {
 		return tcFilterNetModelStr
 	case NetXConnectNoneModel:
 		return noneNetModelStr
+	case NetXConnectNoneTapnetModel:
+		return "tapnet"
 	}
 	return "unknown"
 }
@@ -172,6 +181,9 @@ func (n *NetInterworkingModel) SetModel(modelName string) error {
 		return nil
 	case noneNetModelStr:
 		*n = NetXConnectNoneModel
+		return nil
+	case "tapnet":
+		*n = NetXConnectNoneTapnetModel
 		return nil
 	}
 	return fmt.Errorf("Unknown type %s", modelName)

--- a/src/runtime/virtcontainers/network.go
+++ b/src/runtime/virtcontainers/network.go
@@ -124,6 +124,15 @@ const (
 	// NetXConnectNoneModel can be used when the VM is in the host network namespace
 	NetXConnectNoneModel
 
+	// NetXConnectJailNetModel routes VM network traffic through a host-side
+	// proxy: the VM's tap device lives inside an isolated "jail" network
+	// namespace, connected to the host via a veth pair, with iptables
+	// REDIRECT rules steering traffic to the proxy. Unlike
+	// NetXConnectNoneModel, the shim actively creates and tears down this
+	// jail netns, veth pair, and iptables rules.
+	// Corresponds to internetworking_model=jailnet in configuration.toml.
+	NetXConnectJailNetModel
+
 	// NetXConnectNoneTapnetModel replaces the kernel tap device entirely: the
 	// VM's virtio-net device is backed by a Unix socketpair, one end owned by
 	// QEMU and the other handed off (via SCM_RIGHTS) to a host-sidecar proxy
@@ -149,6 +158,8 @@ const (
 	tcFilterNetModelStr = "tcfilter"
 
 	noneNetModelStr = "none"
+
+	jailNetModelStr = "jailnet"
 )
 
 // GetModel returns the string value of a NetInterworkingModel
@@ -162,6 +173,8 @@ func (n *NetInterworkingModel) GetModel() string {
 		return tcFilterNetModelStr
 	case NetXConnectNoneModel:
 		return noneNetModelStr
+	case NetXConnectJailNetModel:
+		return jailNetModelStr
 	case NetXConnectNoneTapnetModel:
 		return "tapnet"
 	}
@@ -182,6 +195,9 @@ func (n *NetInterworkingModel) SetModel(modelName string) error {
 		return nil
 	case noneNetModelStr:
 		*n = NetXConnectNoneModel
+		return nil
+	case jailNetModelStr:
+		*n = NetXConnectJailNetModel
 		return nil
 	case "tapnet":
 		*n = NetXConnectNoneTapnetModel

--- a/src/runtime/virtcontainers/network.go
+++ b/src/runtime/virtcontainers/network.go
@@ -160,6 +160,8 @@ const (
 	noneNetModelStr = "none"
 
 	jailNetModelStr = "jailnet"
+
+	tapNetModelStr = "tapnet"
 )
 
 // GetModel returns the string value of a NetInterworkingModel
@@ -176,7 +178,7 @@ func (n *NetInterworkingModel) GetModel() string {
 	case NetXConnectJailNetModel:
 		return jailNetModelStr
 	case NetXConnectNoneTapnetModel:
-		return "tapnet"
+		return tapNetModelStr
 	}
 	return "unknown"
 }
@@ -199,7 +201,7 @@ func (n *NetInterworkingModel) SetModel(modelName string) error {
 	case jailNetModelStr:
 		*n = NetXConnectJailNetModel
 		return nil
-	case "tapnet":
+	case tapNetModelStr:
 		*n = NetXConnectNoneTapnetModel
 		return nil
 	}

--- a/src/runtime/virtcontainers/network.go
+++ b/src/runtime/virtcontainers/network.go
@@ -124,10 +124,11 @@ const (
 	// NetXConnectNoneModel can be used when the VM is in the host network namespace
 	NetXConnectNoneModel
 
-	// NetXConnectNoneTapnetModel is like NetXConnectNoneModel but the tap is
-	// created directly in the pod network namespace (no jail netns, no veth).
-	// The host-sidecar proxy opens the tap fd and drives a gvisor-tap-vsock
-	// user-space network stack; no iptables rules are installed by the shim.
+	// NetXConnectNoneTapnetModel replaces the kernel tap device entirely: the
+	// VM's virtio-net device is backed by a Unix socketpair, one end owned by
+	// QEMU and the other handed off (via SCM_RIGHTS) to a host-sidecar proxy
+	// that drives a gvisor-tap-vsock user-space network stack. No tap device,
+	// jail netns, veth, or iptables rule is created by the shim.
 	// Corresponds to internetworking_model=tapnet in configuration.toml.
 	NetXConnectNoneTapnetModel
 

--- a/src/runtime/virtcontainers/network_linux.go
+++ b/src/runtime/virtcontainers/network_linux.go
@@ -132,6 +132,12 @@ func (n *LinuxNetwork) trace(ctx context.Context, name string) (otelTrace.Span, 
 
 func (n *LinuxNetwork) addSingleEndpoint(ctx context.Context, s *Sandbox, netInfo NetworkInfo, hotplug bool) (Endpoint, error) {
 	var endpoint Endpoint
+	// idx identifies this endpoint within the sandbox (e.g. for naming
+	// br0_kata/tap0_kata); -1 for the physical-interface branch, which
+	// never uses it. Declared here (rather than inside the else block
+	// below) so it also survives to the sandbox-ID assignment after the
+	// shared err check.
+	idx := -1
 	// TODO: This is the incoming interface
 	// based on the incoming interface we should create
 	// an appropriate EndPoint based on interface type
@@ -154,7 +160,7 @@ func (n *LinuxNetwork) addSingleEndpoint(ctx context.Context, s *Sandbox, netInf
 		endpoint, err = createPhysicalEndpoint(netInfo)
 	} else {
 		var socketPath string
-		idx := len(n.eps)
+		idx = len(n.eps)
 
 		// Avoid endpoint naming conflicts
 		// When creating a new endpoint, we check existing endpoint names and automatically adjust the naming of the new endpoint to ensure uniqueness.
@@ -231,6 +237,18 @@ func (n *LinuxNetwork) addSingleEndpoint(ctx context.Context, s *Sandbox, netInf
 
 	if err != nil {
 		return nil, err
+	}
+
+	// Give none/tapnet a host-global-safe, externally-discoverable ID to
+	// name their host-global resources (jail netns, tapnet control socket)
+	// by: replace the fresh random UUID createNetworkInterfacePair generated
+	// with one derived from the sandbox ID, which callers outside the shim
+	// (e.g. a host-side proxy sidecar) already know from the CRI/OCI sandbox
+	// ID, unlike a UUID minted deep inside virtcontainers. Still unique
+	// across sandboxes (sandbox ID) and across a sandbox's own interfaces
+	// (idx), so this doesn't reintroduce the collision the UUID switch fixed.
+	if netPair := endpoint.NetworkPair(); netPair != nil {
+		netPair.ID = fmt.Sprintf("%s-%d", s.ID(), idx)
 	}
 
 	endpoint.SetProperties(netInfo)
@@ -1435,10 +1453,11 @@ const (
 // jailNetnsName returns the /run/netns name for the jail netns created by
 // setupNoneNetworking so that removeNoneNetworking can look it up by name.
 //
-// id must be unique per sandbox (netPair.ID, a UUID) rather than the tap
-// interface name (netPair.TAPIface.Name, e.g. "tap0_kata") — the jail netns
-// is a host-global resource, unlike the tap device itself which is scoped to
-// the sandbox's own pod netns, so reusing the per-sandbox tap name here would
+// id must be globally unique (netPair.ID, set in addSingleEndpoint to
+// "<sandbox ID>-<interface index>") rather than the tap interface name
+// (netPair.TAPIface.Name, e.g. "tap0_kata") — the jail netns is a
+// host-global resource, unlike the tap device itself which is scoped to the
+// sandbox's own pod netns, so reusing the per-sandbox tap name here would
 // collide across sandboxes that both happen to be on their first interface.
 func jailNetnsName(id string) string {
 	return "kata-jail-" + id
@@ -1741,10 +1760,13 @@ func removeNoneNetworking(ctx context.Context, endpoint Endpoint) error {
 const tapnetSocketDir = "/run/kata-tapnet"
 
 // tapnetCtrlPath returns the control socket path for a sandbox's tapnet
-// endpoint. id must be unique per sandbox (netPair.ID, a UUID) — the socket
-// lives in a host-global directory, so using the per-sandbox tap interface
-// name here (e.g. "tap0_kata") would collide across sandboxes that both
-// happen to be on their first interface.
+// endpoint. id must be globally unique (netPair.ID, set in addSingleEndpoint
+// to "<sandbox ID>-<interface index>") — the socket lives in a host-global
+// directory, so using the per-sandbox tap interface name here (e.g.
+// "tap0_kata") would collide across sandboxes that both happen to be on
+// their first interface. Deriving it from the sandbox ID (rather than a
+// fresh random UUID) also makes the path predictable to a proxy sidecar
+// that already knows its own CRI sandbox ID.
 func tapnetCtrlPath(id string) string {
 	return filepath.Join(tapnetSocketDir, id+".ctrl")
 }

--- a/src/runtime/virtcontainers/network_linux.go
+++ b/src/runtime/virtcontainers/network_linux.go
@@ -478,7 +478,7 @@ func (n *LinuxNetwork) scanEndpointsInNs(ctx context.Context, s *Sandbox, nsPath
 			continue
 		}
 
-		// Skip proxy-managed veth interfaces created by setupNoneNetworking.
+		// Skip proxy-managed veth interfaces created by setupJailNetNetworking.
 		// A stale kata-pvp in the pod netns (left by a failed prior attempt)
 		// must not be treated as a VM endpoint.
 		if netInfo.Iface.Name == proxyPodVethName {
@@ -915,9 +915,9 @@ func xConnectVMNetwork(ctx context.Context, endpoint Endpoint, h Hypervisor) err
 	case NetXConnectTCFilterModel:
 		networkLogger().Info("connect TCFilter to VM network")
 		err = setupTCFiltering(ctx, endpoint, queues, disableVhostNet)
-	case NetXConnectNoneModel:
-		networkLogger().Info("connect none model to VM network (iptables proxy)")
-		err = setupNoneNetworking(ctx, endpoint, queues, disableVhostNet)
+	case NetXConnectJailNetModel:
+		networkLogger().Info("connect jailnet model to VM network (iptables proxy)")
+		err = setupJailNetNetworking(ctx, endpoint, queues, disableVhostNet)
 	case NetXConnectNoneTapnetModel:
 		networkLogger().Info("connect none model to VM network (tapnet proxy)")
 		err = setupTapnetNetworking(ctx, endpoint, queues, disableVhostNet)
@@ -945,8 +945,8 @@ func xDisconnectVMNetwork(ctx context.Context, endpoint Endpoint) error {
 		err = untapNetworkPair(ctx, endpoint)
 	case NetXConnectTCFilterModel:
 		err = removeTCFiltering(ctx, endpoint)
-	case NetXConnectNoneModel:
-		err = removeNoneNetworking(ctx, endpoint)
+	case NetXConnectJailNetModel:
+		err = removeJailNetNetworking(ctx, endpoint)
 	case NetXConnectNoneTapnetModel:
 		err = removeTapnetNetworking(ctx, endpoint)
 	default:
@@ -1413,12 +1413,12 @@ func removeTCFiltering(ctx context.Context, endpoint Endpoint) error {
 	return nil
 }
 
-// Addressing shared by internetworking_model=none and internetworking_model=tapnet.
+// Addressing shared by internetworking_model=jailnet and internetworking_model=tapnet.
 //
 // Both models give the VM 169.254.1.2/30 with a default route via the tap
 // host address 169.254.1.1, where the host-side proxy acts as gateway.
 //
-// none: the VM runs inside an isolated "jail" network namespace that
+// jailnet: the VM runs inside an isolated "jail" network namespace that
 // contains only tap0_kata. A veth pair bridges the jail netns to the pod
 // netns:
 //
@@ -1451,7 +1451,7 @@ const (
 )
 
 // jailNetnsName returns the /run/netns name for the jail netns created by
-// setupNoneNetworking so that removeNoneNetworking can look it up by name.
+// setupJailNetNetworking so that removeJailNetNetworking can look it up by name.
 //
 // id must be globally unique (netPair.ID, set in addSingleEndpoint to
 // "<sandbox ID>-<interface index>") rather than the tap interface name
@@ -1463,7 +1463,7 @@ func jailNetnsName(id string) string {
 	return "kata-jail-" + id
 }
 
-// setupNoneNetworking creates an isolated jail network namespace containing
+// setupJailNetNetworking creates an isolated jail network namespace containing
 // only the kata tap device, connects it to the pod netns via a veth pair, and
 // configures routing so the host-sidecar proxy can intercept all VM egress.
 //
@@ -1471,8 +1471,8 @@ func jailNetnsName(id string) string {
 // (169.254.1.1).  The proxy's iptables REDIRECT rules (applied in the pod
 // netns on kata-pvp) intercept TCP and DNS-UDP; everything else is dropped by
 // the pod netns default FORWARD policy — structurally no bypass is possible.
-func setupNoneNetworking(ctx context.Context, endpoint Endpoint, queues int, disableVhostNet bool) (err error) {
-	span, _ := networkTrace(ctx, "setupNoneNetworking", endpoint)
+func setupJailNetNetworking(ctx context.Context, endpoint Endpoint, queues int, disableVhostNet bool) (err error) {
+	span, _ := networkTrace(ctx, "setupJailNetNetworking", endpoint)
 	defer span.End()
 
 	netPair := endpoint.NetworkPair()
@@ -1521,7 +1521,7 @@ func setupNoneNetworking(ctx context.Context, endpoint Endpoint, queues int, dis
 	defer netns.Set(podNsFd) //nolint:errcheck
 
 	// Create and enter the jail netns.  NewNamed bind-mounts it at
-	// /run/netns/<name> so removeNoneNetworking can open it by name.
+	// /run/netns/<name> so removeJailNetNetworking can open it by name.
 	jailNsFd, err := netns.NewNamed(jailNS)
 	if err != nil {
 		return fmt.Errorf("create jail netns: %w", err)
@@ -1667,7 +1667,7 @@ func setupNoneNetworking(ctx context.Context, endpoint Endpoint, queues int, dis
 
 // setProxyVMEndpointProps tells kata-agent to configure the VM with the
 // tap-subnet IP (169.254.1.2/30) and a default route via the tap host
-// address (169.254.1.1), shared by both the none and tapnet models.
+// address (169.254.1.1), shared by both the jailnet and tapnet models.
 func setProxyVMEndpointProps(endpoint Endpoint) error {
 	vmAddr, err := netlink.ParseAddr(proxyTapVMCIDR)
 	if err != nil {
@@ -1690,10 +1690,10 @@ func setProxyVMEndpointProps(endpoint Endpoint) error {
 	return nil
 }
 
-// removeNoneNetworking tears down the jail netns and veth pair created by
-// setupNoneNetworking.
-func removeNoneNetworking(ctx context.Context, endpoint Endpoint) error {
-	span, _ := networkTrace(ctx, "removeNoneNetworking", endpoint)
+// removeJailNetNetworking tears down the jail netns and veth pair created by
+// setupJailNetNetworking.
+func removeJailNetNetworking(ctx context.Context, endpoint Endpoint) error {
+	span, _ := networkTrace(ctx, "removeJailNetNetworking", endpoint)
 	defer span.End()
 
 	netPair := endpoint.NetworkPair()
@@ -1708,10 +1708,10 @@ func removeNoneNetworking(ctx context.Context, endpoint Endpoint) error {
 
 	if podVeth, err := podHandle.LinkByName(proxyPodVethName); err == nil {
 		if err := podHandle.LinkDel(podVeth); err != nil {
-			networkLogger().WithError(err).WithField("iface", proxyPodVethName).Warn("removeNoneNetworking: pod veth delete failed")
+			networkLogger().WithError(err).WithField("iface", proxyPodVethName).Warn("removeJailNetNetworking: pod veth delete failed")
 		}
 	} else if !errors.As(err, &netlink.LinkNotFoundError{}) {
-		networkLogger().WithError(err).WithField("iface", proxyPodVethName).Warn("removeNoneNetworking: pod veth lookup failed")
+		networkLogger().WithError(err).WithField("iface", proxyPodVethName).Warn("removeJailNetNetworking: pod veth lookup failed")
 	}
 
 	// Enter the jail netns to remove the tap, then delete the named netns.
@@ -1743,10 +1743,10 @@ func removeNoneNetworking(ctx context.Context, endpoint Endpoint) error {
 
 	if tapLink, err := getLinkByName(jailHandle, netPair.TAPIface.Name, &netlink.Tuntap{}); err == nil {
 		if err := jailHandle.LinkSetDown(tapLink); err != nil {
-			networkLogger().WithError(err).WithField("iface", netPair.TAPIface.Name).Warn("removeNoneNetworking: tap set-down failed")
+			networkLogger().WithError(err).WithField("iface", netPair.TAPIface.Name).Warn("removeJailNetNetworking: tap set-down failed")
 		}
 		if err := jailHandle.LinkDel(tapLink); err != nil {
-			networkLogger().WithError(err).WithField("iface", netPair.TAPIface.Name).Warn("removeNoneNetworking: tap delete failed")
+			networkLogger().WithError(err).WithField("iface", netPair.TAPIface.Name).Warn("removeJailNetNetworking: tap delete failed")
 		}
 	}
 
@@ -2189,10 +2189,10 @@ func addTxRateLimiter(endpoint Endpoint, maxRate uint64) error {
 				return err
 			}
 			return addHTBQdisc(link.Attrs().Index, maxRate)
-		case NetXConnectMacVtapModel:
+		case NetXConnectMacVtapModel, NetXConnectNoneModel:
 			linkName = netPair.TAPIface.Name
-		case NetXConnectNoneModel, NetXConnectNoneTapnetModel:
-			// none's tap lives inside a jail netns unreachable by name from
+		case NetXConnectJailNetModel, NetXConnectNoneTapnetModel:
+			// jailnet's tap lives inside a jail netns unreachable by name from
 			// here, and tapnet has no tap device at all (a Unix socketpair
 			// backs the VM's virtio-net instead) — neither has a link this
 			// function can shape.
@@ -2288,9 +2288,9 @@ func removeTxRateLimiter(endpoint Endpoint, networkNSPath string) error {
 				return err
 			}
 			return nil
-		case NetXConnectMacVtapModel:
+		case NetXConnectMacVtapModel, NetXConnectNoneModel:
 			linkName = netPair.TAPIface.Name
-		case NetXConnectNoneModel, NetXConnectNoneTapnetModel:
+		case NetXConnectJailNetModel, NetXConnectNoneTapnetModel:
 			// See the matching case in addTxRateLimiter: neither model has a
 			// link reachable by name here, so a rate limiter can never have
 			// been successfully attached for them in the first place.

--- a/src/runtime/virtcontainers/network_linux.go
+++ b/src/runtime/virtcontainers/network_linux.go
@@ -14,6 +14,7 @@ import (
 	"net"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"regexp"
 	"runtime"
 	"sort"
@@ -886,6 +887,9 @@ func xConnectVMNetwork(ctx context.Context, endpoint Endpoint, h Hypervisor) err
 	case NetXConnectTCFilterModel:
 		networkLogger().Info("connect TCFilter to VM network")
 		err = setupTCFiltering(ctx, endpoint, queues, disableVhostNet)
+	case NetXConnectNoneTapnetModel:
+		networkLogger().Info("connect none model to VM network (tapnet proxy)")
+		err = setupTapnetNetworking(ctx, endpoint, queues, disableVhostNet)
 	default:
 		err = fmt.Errorf("Invalid internetworking model")
 	}
@@ -910,6 +914,8 @@ func xDisconnectVMNetwork(ctx context.Context, endpoint Endpoint) error {
 		err = untapNetworkPair(ctx, endpoint)
 	case NetXConnectTCFilterModel:
 		err = removeTCFiltering(ctx, endpoint)
+	case NetXConnectNoneTapnetModel:
+		err = removeTapnetNetworking(ctx, endpoint)
 	default:
 		err = fmt.Errorf("Invalid internetworking model")
 	}
@@ -1374,6 +1380,165 @@ func removeTCFiltering(ctx context.Context, endpoint Endpoint) error {
 	return nil
 }
 
+// Addressing for internetworking_model=tapnet.
+//
+// The proxy's gvisor-tap-vsock user-space stack acts as gateway for the VM at
+// 169.254.1.1; the VM is configured with 169.254.1.2 and a default route via
+// the gateway. No kernel tap device, netns, or iptables rule is involved —
+// the VM's virtio-net device is backed directly by a Unix socketpair whose
+// far end the proxy owns.
+const (
+	proxyTapHostCIDR = "169.254.1.1/30"
+	proxyTapVMCIDR   = "169.254.1.2/30"
+)
+
+const tapnetSocketDir = "/run/kata-tapnet"
+
+func tapnetCtrlPath(tapName string) string {
+	return filepath.Join(tapnetSocketDir, tapName+".ctrl")
+}
+
+// setupTapnetNetworking prepares the pod netns for the QEMU socketpair
+// tapnet model (internetworking_model=tapnet).
+//
+// A Unix socketpair is created.  The VM end (fd_vm) is passed to QEMU via
+// VMFds as -netdev socket,fd=<N>.  Because both ends of the socketpair are
+// connected at launch, the virtio-net device always has a live backend and
+// the VM boots reliably without racing against the proxy container startup.
+//
+// The proxy end (fd_ctrl) is held by a shim goroutine (serveTapnetCtrl) that
+// drains VM TX frames and waits for the proxy container to connect to the
+// control socket at /run/kata-tapnet/<tap>.ctrl.  When the proxy connects,
+// fd_ctrl is handed off via SCM_RIGHTS.
+//
+// Note: after the proxy is killed, fd_ctrl closes and QEMU marks the
+// virtio-net link down.  Reconnection requires restarting the pod (QEMU
+// holds a fixed fd and cannot accept a new socketpair end).
+func setupTapnetNetworking(ctx context.Context, endpoint Endpoint, queues int, disableVhostNet bool) error {
+	span, _ := networkTrace(ctx, "setupTapnetNetworking", endpoint)
+	defer span.End()
+
+	netPair := endpoint.NetworkPair()
+
+	podHandle, err := netlink.NewHandle()
+	if err != nil {
+		return err
+	}
+	defer podHandle.Close()
+
+	// Read the pod veth MAC so QEMU can set the correct MAC on the virtio-net device.
+	link, err := getLinkForEndpoint(endpoint, podHandle)
+	if err != nil {
+		return err
+	}
+	netPair.TAPIface.HardAddr = link.Attrs().HardwareAddr.String()
+
+	// Create a Unix socketpair.  fds[0] (VM end) goes to QEMU; fds[1] (ctrl
+	// end) is held by the shim until the proxy container connects.
+	fds, err := unix.Socketpair(unix.AF_UNIX, unix.SOCK_STREAM|unix.SOCK_CLOEXEC, 0)
+	if err != nil {
+		return fmt.Errorf("tapnet socketpair: %w", err)
+	}
+	vmFile := os.NewFile(uintptr(fds[0]), "tapnet-vm")
+	ctrlFile := os.NewFile(uintptr(fds[1]), "tapnet-ctrl")
+
+	netPair.VMFds = []*os.File{vmFile}
+
+	// Ensure socket directory exists and launch the control socket goroutine.
+	if err := os.MkdirAll(tapnetSocketDir, 0o700); err != nil {
+		vmFile.Close()
+		ctrlFile.Close()
+		return fmt.Errorf("create tapnet socket dir: %w", err)
+	}
+	go serveTapnetCtrl(tapnetCtrlPath(netPair.TAPIface.Name), ctrlFile)
+
+	// Tell kata-agent to configure the VM with 169.254.1.2/30 and a default
+	// route via 169.254.1.1 (where the gvisor-tap-vsock proxy acts as gateway).
+	vmAddr, err := netlink.ParseAddr(proxyTapVMCIDR)
+	if err != nil {
+		return fmt.Errorf("parse tap VM addr: %w", err)
+	}
+	tapHostAddr, err := netlink.ParseAddr(proxyTapHostCIDR)
+	if err != nil {
+		return fmt.Errorf("parse tap host addr: %w", err)
+	}
+	_, tapNet, _ := net.ParseCIDR(proxyTapHostCIDR)
+
+	props := endpoint.Properties()
+	props.Addrs = []netlink.Addr{*vmAddr}
+	props.Routes = []netlink.Route{
+		{Dst: tapNet, Gw: nil, Scope: netlink.SCOPE_LINK},
+		{Dst: nil, Gw: tapHostAddr.IP},
+	}
+	endpoint.SetProperties(props)
+
+	return nil
+}
+
+// removeTapnetNetworking cleans up after setupTapnetNetworking.
+func removeTapnetNetworking(ctx context.Context, endpoint Endpoint) error {
+	span, _ := networkTrace(ctx, "removeTapnetNetworking", endpoint)
+	defer span.End()
+	netPair := endpoint.NetworkPair()
+	_ = os.Remove(tapnetCtrlPath(netPair.TAPIface.Name))
+	return nil
+}
+
+// serveTapnetCtrl is the shim-side goroutine for tapnet fd handoff.
+// It drains ctrlFile (VM TX frames) to prevent the socketpair buffer from
+// filling, then listens on ctrlPath for the proxy container to connect.
+// When the proxy connects, ctrlFile is sent via SCM_RIGHTS and the goroutine
+// exits.
+func serveTapnetCtrl(ctrlPath string, ctrlFile *os.File) {
+	defer ctrlFile.Close()
+
+	// Drain VM TX frames from ctrlFile until handoff or error.
+	go drainFile(ctrlFile)
+
+	// Remove any stale ctrl socket from a previous run.
+	_ = os.Remove(ctrlPath)
+
+	ln, err := net.Listen("unix", ctrlPath)
+	if err != nil {
+		networkLogger().WithError(err).Error("tapnet ctrl: listen failed")
+		return
+	}
+	defer ln.Close()
+
+	conn, err := ln.Accept()
+	if err != nil {
+		return
+	}
+	defer conn.Close()
+
+	// Send ctrlFile to the proxy via SCM_RIGHTS.
+	uc, ok := conn.(*net.UnixConn)
+	if !ok {
+		return
+	}
+	cf, err := uc.File()
+	if err != nil {
+		return
+	}
+	defer cf.Close()
+
+	rights := unix.UnixRights(int(ctrlFile.Fd()))
+	if _, err := unix.SendmsgN(int(cf.Fd()), []byte{0}, rights, nil, 0); err != nil {
+		networkLogger().WithError(err).Error("tapnet ctrl: SCM_RIGHTS send failed")
+	}
+	// ctrlFile.Close() is called by the defer above; the drain goroutine exits on EOF/EBADF.
+}
+
+// drainFile reads and discards all data from f until it returns an error.
+func drainFile(f *os.File) {
+	buf := make([]byte, 4096)
+	for {
+		if _, err := f.Read(buf); err != nil {
+			return
+		}
+	}
+}
+
 // doNetNS is free from any call to a go routine, and it calls
 // into runtime.LockOSThread(), meaning it won't be executed in a
 // different thread than the one expected by the caller.
@@ -1639,7 +1804,7 @@ func addTxRateLimiter(endpoint Endpoint, maxRate uint64) error {
 				return err
 			}
 			return addHTBQdisc(link.Attrs().Index, maxRate)
-		case NetXConnectMacVtapModel, NetXConnectNoneModel:
+		case NetXConnectMacVtapModel, NetXConnectNoneModel, NetXConnectNoneTapnetModel:
 			linkName = netPair.TAPIface.Name
 		default:
 			return fmt.Errorf("Unsupported inter-networking model %v for adding tx rate limiter", netPair.NetInterworkingModel)
@@ -1732,7 +1897,7 @@ func removeTxRateLimiter(endpoint Endpoint, networkNSPath string) error {
 				return err
 			}
 			return nil
-		case NetXConnectMacVtapModel, NetXConnectNoneModel:
+		case NetXConnectMacVtapModel, NetXConnectNoneModel, NetXConnectNoneTapnetModel:
 			linkName = netPair.TAPIface.Name
 		}
 	case *MacvtapEndpoint, *TapEndpoint:

--- a/src/runtime/virtcontainers/network_linux.go
+++ b/src/runtime/virtcontainers/network_linux.go
@@ -1427,10 +1427,15 @@ func removeTCFiltering(ctx context.Context, endpoint Endpoint) error {
 //	pod  netns:                               kata-pvp (169.254.2.2/30) ─── eth0
 //
 // The proxy (running in the pod netns) installs iptables REDIRECT rules on
-// kata-pvp. Traffic arriving from the VM crosses the veth and is intercepted
-// by REDIRECT before it can reach eth0. Non-TCP/DNS traffic has no forwarding
-// path to eth0 and is dropped — no bypass is possible, but coverage is
-// limited to TCP and UDP/53.
+// kata-pvp. Traffic arriving from the VM crosses the veth and, if matched by
+// a REDIRECT rule, is intercepted before it can reach eth0. This code does
+// not itself enforce anything beyond that: enabling ip_forward inside the
+// jail netns (see setupJailNetNetworking) is what lets the kernel move
+// packets from the tap onto the veth in the first place, so any protocol the
+// proxy's REDIRECT rules don't match is only blocked if the proxy has also
+// installed a scoped drop for kata-pvp in its own FORWARD chain (see
+// how-to-use-host-side-proxy-networking.md). Without that second rule,
+// unmatched traffic is not dropped — it is forwarded to eth0 unmodified.
 //
 // tapnet: no kernel tap device, netns, or iptables rule is involved — the
 // VM's virtio-net device is backed directly by a Unix socketpair whose far
@@ -1468,9 +1473,12 @@ func jailNetnsName(id string) string {
 // configures routing so the host-sidecar proxy can intercept all VM egress.
 //
 // The VM gets 169.254.1.2/30 with a default route via the tap host address
-// (169.254.1.1).  The proxy's iptables REDIRECT rules (applied in the pod
-// netns on kata-pvp) intercept TCP and DNS-UDP; everything else is dropped by
-// the pod netns default FORWARD policy — structurally no bypass is possible.
+// (169.254.1.1).  This function only sets up the plumbing (tap, veth, routes,
+// ip_forward=1 inside the jail netns) — it installs no iptables rules of its
+// own.  Whether unredirected traffic is dropped or silently forwarded to
+// eth0 depends entirely on the proxy installing both its REDIRECT rules and
+// a matching drop rule for kata-pvp in its own FORWARD chain; this function
+// makes forwarding possible, it does not make it safe on its own.
 func setupJailNetNetworking(ctx context.Context, endpoint Endpoint, queues int, disableVhostNet bool) (err error) {
 	span, _ := networkTrace(ctx, "setupJailNetNetworking", endpoint)
 	defer span.End()

--- a/src/runtime/virtcontainers/network_linux.go
+++ b/src/runtime/virtcontainers/network_linux.go
@@ -10,6 +10,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"math/rand"
 	"net"
 	"os"
@@ -20,6 +21,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 	"syscall"
 	"time"
 
@@ -1420,7 +1422,9 @@ const (
 	proxyTapHostCIDR  = "169.254.1.1/30"
 	proxyTapVMCIDR    = "169.254.1.2/30"
 	proxyJailVethCIDR = "169.254.2.1/30"
+	proxyJailVethIP   = "169.254.2.1"
 	proxyPodVethCIDR  = "169.254.2.2/30"
+	proxyPodVethIP    = "169.254.2.2"
 )
 
 const (
@@ -1428,10 +1432,16 @@ const (
 	proxyPodVethName  = "kata-pvp"
 )
 
-// jailNetnsName returns the /var/run/netns name for the jail netns created by
+// jailNetnsName returns the /run/netns name for the jail netns created by
 // setupNoneNetworking so that removeNoneNetworking can look it up by name.
-func jailNetnsName(tapName string) string {
-	return "kata-jail-" + tapName
+//
+// id must be unique per sandbox (netPair.ID, a UUID) rather than the tap
+// interface name (netPair.TAPIface.Name, e.g. "tap0_kata") — the jail netns
+// is a host-global resource, unlike the tap device itself which is scoped to
+// the sandbox's own pod netns, so reusing the per-sandbox tap name here would
+// collide across sandboxes that both happen to be on their first interface.
+func jailNetnsName(id string) string {
+	return "kata-jail-" + id
 }
 
 // setupNoneNetworking creates an isolated jail network namespace containing
@@ -1442,11 +1452,12 @@ func jailNetnsName(tapName string) string {
 // (169.254.1.1).  The proxy's iptables REDIRECT rules (applied in the pod
 // netns on kata-pvp) intercept TCP and DNS-UDP; everything else is dropped by
 // the pod netns default FORWARD policy — structurally no bypass is possible.
-func setupNoneNetworking(ctx context.Context, endpoint Endpoint, queues int, disableVhostNet bool) error {
+func setupNoneNetworking(ctx context.Context, endpoint Endpoint, queues int, disableVhostNet bool) (err error) {
 	span, _ := networkTrace(ctx, "setupNoneNetworking", endpoint)
 	defer span.End()
 
 	netPair := endpoint.NetworkPair()
+	jailNS := jailNetnsName(netPair.ID)
 
 	// Gather endpoint attributes (MTU, MAC) from the pod netns before we leave it.
 	podHandle, err := netlink.NewHandle()
@@ -1461,8 +1472,8 @@ func setupNoneNetworking(ctx context.Context, endpoint Endpoint, queues int, dis
 	// bind-mounted (partial failure), Unmount returns EINVAL and the file is
 	// left behind.  Fall back to a direct Remove so NewNamed always gets a
 	// clean slate.
-	if err := netns.DeleteNamed(jailNetnsName(netPair.TAPIface.Name)); err != nil {
-		_ = os.Remove("/run/netns/" + jailNetnsName(netPair.TAPIface.Name))
+	if err := netns.DeleteNamed(jailNS); err != nil {
+		_ = os.Remove("/run/netns/" + jailNS)
 	}
 	if podVeth, err := podHandle.LinkByName(proxyPodVethName); err == nil {
 		_ = podHandle.LinkDel(podVeth)
@@ -1483,10 +1494,16 @@ func setupNoneNetworking(ctx context.Context, endpoint Endpoint, queues int, dis
 		return fmt.Errorf("get pod netns: %w", err)
 	}
 	defer podNsFd.Close()
+	// Safety net for every early return below: without this, an error
+	// returned while the OS thread is still switched into the jail netns
+	// would leave that netns binding on the thread after UnlockOSThread
+	// releases it back to the runtime's pool, silently relocating whichever
+	// goroutine the runtime schedules onto it next.
+	defer netns.Set(podNsFd) //nolint:errcheck
 
 	// Create and enter the jail netns.  NewNamed bind-mounts it at
-	// /var/run/netns/<name> so removeNoneNetworking can open it by name.
-	jailNsFd, err := netns.NewNamed(jailNetnsName(netPair.TAPIface.Name))
+	// /run/netns/<name> so removeNoneNetworking can open it by name.
+	jailNsFd, err := netns.NewNamed(jailNS)
 	if err != nil {
 		return fmt.Errorf("create jail netns: %w", err)
 	}
@@ -1504,6 +1521,13 @@ func setupNoneNetworking(ctx context.Context, endpoint Endpoint, queues int, dis
 		return fmt.Errorf("could not create TAP interface: %w", err)
 	}
 	netPair.VMFds = fds
+	defer func() {
+		if err != nil {
+			for _, f := range fds {
+				f.Close()
+			}
+		}
+	}()
 
 	if !disableVhostNet {
 		vhostFds, err := createVhostFds(queues)
@@ -1511,6 +1535,13 @@ func setupNoneNetworking(ctx context.Context, endpoint Endpoint, queues int, dis
 			return fmt.Errorf("could not setup vhost fds %s: %w", netPair.VirtIface.Name, err)
 		}
 		netPair.VhostFds = vhostFds
+		defer func() {
+			if err != nil {
+				for _, f := range vhostFds {
+					f.Close()
+				}
+			}
+		}()
 	}
 
 	netPair.TAPIface.HardAddr = attrs.HardwareAddr.String()
@@ -1563,7 +1594,7 @@ func setupNoneNetworking(ctx context.Context, endpoint Endpoint, queues int, dis
 	}
 	if err := jailHandle.RouteAdd(&netlink.Route{
 		LinkIndex: jailVeth.Attrs().Index,
-		Gw:        net.ParseIP("169.254.2.2"),
+		Gw:        net.ParseIP(proxyPodVethIP),
 	}); err != nil {
 		return fmt.Errorf("jail default route: %w", err)
 	}
@@ -1603,20 +1634,29 @@ func setupNoneNetworking(ctx context.Context, endpoint Endpoint, queues int, dis
 	if err := podHandle2.LinkSetUp(podVeth); err != nil {
 		return fmt.Errorf("enable pod veth: %w", err)
 	}
-	_, vmSubnet, _ := net.ParseCIDR("169.254.1.0/30")
+	_, vmSubnet, _ := net.ParseCIDR(proxyTapHostCIDR)
 	if err := podHandle2.RouteAdd(&netlink.Route{
 		LinkIndex: podVeth.Attrs().Index,
 		Dst:       vmSubnet,
-		Gw:        net.ParseIP("169.254.2.1"),
+		Gw:        net.ParseIP(proxyJailVethIP),
 	}); err != nil {
 		return fmt.Errorf("pod netns VM route: %w", err)
 	}
 
-	// Tell kata-agent to configure the VM with the tap-subnet IP and a default
-	// route via the tap host address.
+	return setProxyVMEndpointProps(endpoint)
+}
+
+// setProxyVMEndpointProps tells kata-agent to configure the VM with the
+// tap-subnet IP (169.254.1.2/30) and a default route via the tap host
+// address (169.254.1.1), shared by both the none and tapnet models.
+func setProxyVMEndpointProps(endpoint Endpoint) error {
 	vmAddr, err := netlink.ParseAddr(proxyTapVMCIDR)
 	if err != nil {
 		return fmt.Errorf("parse tap VM addr: %w", err)
+	}
+	tapHostAddr, err := netlink.ParseAddr(proxyTapHostCIDR)
+	if err != nil {
+		return fmt.Errorf("parse tap host addr: %w", err)
 	}
 	_, tapNet, _ := net.ParseCIDR(proxyTapHostCIDR)
 
@@ -1638,6 +1678,7 @@ func removeNoneNetworking(ctx context.Context, endpoint Endpoint) error {
 	defer span.End()
 
 	netPair := endpoint.NetworkPair()
+	jailNS := jailNetnsName(netPair.ID)
 
 	// Delete the pod-side veth; the kernel auto-deletes the jail-side peer.
 	podHandle, err := netlink.NewHandle()
@@ -1647,7 +1688,11 @@ func removeNoneNetworking(ctx context.Context, endpoint Endpoint) error {
 	defer podHandle.Close()
 
 	if podVeth, err := podHandle.LinkByName(proxyPodVethName); err == nil {
-		_ = podHandle.LinkDel(podVeth)
+		if err := podHandle.LinkDel(podVeth); err != nil {
+			networkLogger().WithError(err).WithField("iface", proxyPodVethName).Warn("removeNoneNetworking: pod veth delete failed")
+		}
+	} else if !errors.As(err, &netlink.LinkNotFoundError{}) {
+		networkLogger().WithError(err).WithField("iface", proxyPodVethName).Warn("removeNoneNetworking: pod veth lookup failed")
 	}
 
 	// Enter the jail netns to remove the tap, then delete the named netns.
@@ -1661,7 +1706,7 @@ func removeNoneNetworking(ctx context.Context, endpoint Endpoint) error {
 	defer curNsFd.Close()
 	defer netns.Set(curNsFd) //nolint:errcheck
 
-	jailNsFd, err := netns.GetFromName(jailNetnsName(netPair.TAPIface.Name))
+	jailNsFd, err := netns.GetFromName(jailNS)
 	if err != nil {
 		return fmt.Errorf("open jail netns: %w", err)
 	}
@@ -1678,21 +1723,30 @@ func removeNoneNetworking(ctx context.Context, endpoint Endpoint) error {
 	defer jailHandle.Close()
 
 	if tapLink, err := getLinkByName(jailHandle, netPair.TAPIface.Name, &netlink.Tuntap{}); err == nil {
-		jailHandle.LinkSetDown(tapLink) //nolint:errcheck
-		jailHandle.LinkDel(tapLink)     //nolint:errcheck
+		if err := jailHandle.LinkSetDown(tapLink); err != nil {
+			networkLogger().WithError(err).WithField("iface", netPair.TAPIface.Name).Warn("removeNoneNetworking: tap set-down failed")
+		}
+		if err := jailHandle.LinkDel(tapLink); err != nil {
+			networkLogger().WithError(err).WithField("iface", netPair.TAPIface.Name).Warn("removeNoneNetworking: tap delete failed")
+		}
 	}
 
 	if err := netns.Set(curNsFd); err != nil {
 		return fmt.Errorf("restore netns after jail cleanup: %w", err)
 	}
 
-	return netns.DeleteNamed(jailNetnsName(netPair.TAPIface.Name))
+	return netns.DeleteNamed(jailNS)
 }
 
 const tapnetSocketDir = "/run/kata-tapnet"
 
-func tapnetCtrlPath(tapName string) string {
-	return filepath.Join(tapnetSocketDir, tapName+".ctrl")
+// tapnetCtrlPath returns the control socket path for a sandbox's tapnet
+// endpoint. id must be unique per sandbox (netPair.ID, a UUID) — the socket
+// lives in a host-global directory, so using the per-sandbox tap interface
+// name here (e.g. "tap0_kata") would collide across sandboxes that both
+// happen to be on their first interface.
+func tapnetCtrlPath(id string) string {
+	return filepath.Join(tapnetSocketDir, id+".ctrl")
 }
 
 // setupTapnetNetworking prepares the pod netns for the QEMU socketpair
@@ -1711,11 +1765,12 @@ func tapnetCtrlPath(tapName string) string {
 // Note: after the proxy is killed, fd_ctrl closes and QEMU marks the
 // virtio-net link down.  Reconnection requires restarting the pod (QEMU
 // holds a fixed fd and cannot accept a new socketpair end).
-func setupTapnetNetworking(ctx context.Context, endpoint Endpoint, queues int, disableVhostNet bool) error {
+func setupTapnetNetworking(ctx context.Context, endpoint Endpoint, queues int, disableVhostNet bool) (err error) {
 	span, _ := networkTrace(ctx, "setupTapnetNetworking", endpoint)
 	defer span.End()
 
 	netPair := endpoint.NetworkPair()
+	ctrlPath := tapnetCtrlPath(netPair.ID)
 
 	podHandle, err := netlink.NewHandle()
 	if err != nil {
@@ -1738,72 +1793,78 @@ func setupTapnetNetworking(ctx context.Context, endpoint Endpoint, queues int, d
 	}
 	vmFile := os.NewFile(uintptr(fds[0]), "tapnet-vm")
 	ctrlFile := os.NewFile(uintptr(fds[1]), "tapnet-ctrl")
+	defer func() {
+		if err != nil {
+			vmFile.Close()
+			ctrlFile.Close()
+		}
+	}()
 
 	netPair.VMFds = []*os.File{vmFile}
 
-	// Ensure socket directory exists and launch the control socket goroutine.
+	// Ensure the socket directory exists, then listen synchronously (rather
+	// than inside the goroutine below) so the listener can be tracked here
+	// and closed by removeTapnetNetworking on teardown — otherwise a proxy
+	// that never connects leaves serveTapnetCtrl blocked in Accept forever.
 	if err := os.MkdirAll(tapnetSocketDir, 0o700); err != nil {
-		vmFile.Close()
-		ctrlFile.Close()
 		return fmt.Errorf("create tapnet socket dir: %w", err)
 	}
-	go serveTapnetCtrl(tapnetCtrlPath(netPair.TAPIface.Name), ctrlFile)
-
-	// Tell kata-agent to configure the VM with 169.254.1.2/30 and a default
-	// route via 169.254.1.1 (where the gvisor-tap-vsock proxy acts as gateway).
-	vmAddr, err := netlink.ParseAddr(proxyTapVMCIDR)
+	if err := os.Remove(ctrlPath); err != nil && !os.IsNotExist(err) {
+		networkLogger().WithError(err).WithField("path", ctrlPath).Warn("tapnet ctrl: failed to remove stale socket")
+	}
+	ln, err := net.Listen("unix", ctrlPath)
 	if err != nil {
-		return fmt.Errorf("parse tap VM addr: %w", err)
+		return fmt.Errorf("tapnet ctrl listen: %w", err)
 	}
-	tapHostAddr, err := netlink.ParseAddr(proxyTapHostCIDR)
-	if err != nil {
-		return fmt.Errorf("parse tap host addr: %w", err)
-	}
-	_, tapNet, _ := net.ParseCIDR(proxyTapHostCIDR)
+	tapnetListeners.Store(ctrlPath, ln)
 
-	props := endpoint.Properties()
-	props.Addrs = []netlink.Addr{*vmAddr}
-	props.Routes = []netlink.Route{
-		{Dst: tapNet, Gw: nil, Scope: netlink.SCOPE_LINK},
-		{Dst: nil, Gw: tapHostAddr.IP},
-	}
-	endpoint.SetProperties(props)
+	go serveTapnetCtrl(ln, ctrlFile)
 
-	return nil
+	return setProxyVMEndpointProps(endpoint)
 }
+
+// tapnetListeners tracks the live control-socket listener for each tapnet
+// sandbox (keyed by ctrl socket path) so removeTapnetNetworking can close it
+// and unblock serveTapnetCtrl's Accept, even if the proxy never connected.
+var tapnetListeners sync.Map
 
 // removeTapnetNetworking cleans up after setupTapnetNetworking.
 func removeTapnetNetworking(ctx context.Context, endpoint Endpoint) error {
 	span, _ := networkTrace(ctx, "removeTapnetNetworking", endpoint)
 	defer span.End()
 	netPair := endpoint.NetworkPair()
-	_ = os.Remove(tapnetCtrlPath(netPair.TAPIface.Name))
+	ctrlPath := tapnetCtrlPath(netPair.ID)
+
+	if v, ok := tapnetListeners.LoadAndDelete(ctrlPath); ok {
+		if ln, ok := v.(net.Listener); ok {
+			if err := ln.Close(); err != nil {
+				networkLogger().WithError(err).WithField("path", ctrlPath).Warn("tapnet ctrl: listener close failed")
+			}
+		}
+	}
+	if err := os.Remove(ctrlPath); err != nil && !os.IsNotExist(err) {
+		networkLogger().WithError(err).WithField("path", ctrlPath).Warn("tapnet ctrl: failed to remove socket")
+	}
 	return nil
 }
 
-// serveTapnetCtrl is the shim-side goroutine for tapnet fd handoff.
-// It drains ctrlFile (VM TX frames) to prevent the socketpair buffer from
-// filling, then listens on ctrlPath for the proxy container to connect.
-// When the proxy connects, ctrlFile is sent via SCM_RIGHTS and the goroutine
-// exits.
-func serveTapnetCtrl(ctrlPath string, ctrlFile *os.File) {
+// serveTapnetCtrl is the shim-side goroutine for tapnet fd handoff. It drains
+// ctrlFile (VM TX frames) to prevent the socketpair buffer from filling, then
+// accepts on ln (already listening — see setupTapnetNetworking) for the
+// proxy container to connect. When the proxy connects, ctrlFile is sent via
+// SCM_RIGHTS and the goroutine exits. removeTapnetNetworking closing ln is
+// what makes Accept return (with an error) if the proxy never connects.
+func serveTapnetCtrl(ln net.Listener, ctrlFile *os.File) {
 	defer ctrlFile.Close()
 
 	// Drain VM TX frames from ctrlFile until handoff or error.
 	go drainFile(ctrlFile)
 
-	// Remove any stale ctrl socket from a previous run.
-	_ = os.Remove(ctrlPath)
-
-	ln, err := net.Listen("unix", ctrlPath)
-	if err != nil {
-		networkLogger().WithError(err).Error("tapnet ctrl: listen failed")
-		return
-	}
-	defer ln.Close()
-
 	conn, err := ln.Accept()
 	if err != nil {
+		if !errors.Is(err, net.ErrClosed) {
+			networkLogger().WithError(err).Error("tapnet ctrl: accept failed")
+		}
 		return
 	}
 	defer conn.Close()
@@ -1811,10 +1872,12 @@ func serveTapnetCtrl(ctrlPath string, ctrlFile *os.File) {
 	// Send ctrlFile to the proxy via SCM_RIGHTS.
 	uc, ok := conn.(*net.UnixConn)
 	if !ok {
+		networkLogger().WithField("type", fmt.Sprintf("%T", conn)).Error("tapnet ctrl: unexpected connection type")
 		return
 	}
 	cf, err := uc.File()
 	if err != nil {
+		networkLogger().WithError(err).Error("tapnet ctrl: failed to get connection fd")
 		return
 	}
 	defer cf.Close()
@@ -1831,6 +1894,9 @@ func drainFile(f *os.File) {
 	buf := make([]byte, 4096)
 	for {
 		if _, err := f.Read(buf); err != nil {
+			if !errors.Is(err, io.EOF) && !errors.Is(err, os.ErrClosed) {
+				networkLogger().WithError(err).Warn("tapnet ctrl: drain read failed")
+			}
 			return
 		}
 	}
@@ -2101,8 +2167,14 @@ func addTxRateLimiter(endpoint Endpoint, maxRate uint64) error {
 				return err
 			}
 			return addHTBQdisc(link.Attrs().Index, maxRate)
-		case NetXConnectMacVtapModel, NetXConnectNoneModel, NetXConnectNoneTapnetModel:
+		case NetXConnectMacVtapModel:
 			linkName = netPair.TAPIface.Name
+		case NetXConnectNoneModel, NetXConnectNoneTapnetModel:
+			// none's tap lives inside a jail netns unreachable by name from
+			// here, and tapnet has no tap device at all (a Unix socketpair
+			// backs the VM's virtio-net instead) — neither has a link this
+			// function can shape.
+			return fmt.Errorf("tx rate limiting is not supported for inter-networking model %v", netPair.NetInterworkingModel)
 		default:
 			return fmt.Errorf("Unsupported inter-networking model %v for adding tx rate limiter", netPair.NetInterworkingModel)
 		}
@@ -2194,8 +2266,13 @@ func removeTxRateLimiter(endpoint Endpoint, networkNSPath string) error {
 				return err
 			}
 			return nil
-		case NetXConnectMacVtapModel, NetXConnectNoneModel, NetXConnectNoneTapnetModel:
+		case NetXConnectMacVtapModel:
 			linkName = netPair.TAPIface.Name
+		case NetXConnectNoneModel, NetXConnectNoneTapnetModel:
+			// See the matching case in addTxRateLimiter: neither model has a
+			// link reachable by name here, so a rate limiter can never have
+			// been successfully attached for them in the first place.
+			return fmt.Errorf("tx rate limiting is not supported for inter-networking model %v", netPair.NetInterworkingModel)
 		}
 	case *MacvtapEndpoint, *TapEndpoint:
 		linkName = endpoint.Name()

--- a/src/runtime/virtcontainers/network_linux.go
+++ b/src/runtime/virtcontainers/network_linux.go
@@ -458,6 +458,14 @@ func (n *LinuxNetwork) scanEndpointsInNs(ctx context.Context, s *Sandbox, nsPath
 			continue
 		}
 
+		// Skip proxy-managed veth interfaces created by setupNoneNetworking.
+		// A stale kata-pvp in the pod netns (left by a failed prior attempt)
+		// must not be treated as a VM endpoint.
+		if netInfo.Iface.Name == proxyPodVethName {
+			networkLogger().WithField("endpoint", netInfo.Iface.Name).Info("skipping proxy veth")
+			continue
+		}
+
 		if err := doNetNS(nsPath, func(_ ns.NetNS) error {
 			ep, addErr := n.addSingleEndpoint(ctx, s, netInfo, hotplug)
 			if addErr == nil {
@@ -887,6 +895,9 @@ func xConnectVMNetwork(ctx context.Context, endpoint Endpoint, h Hypervisor) err
 	case NetXConnectTCFilterModel:
 		networkLogger().Info("connect TCFilter to VM network")
 		err = setupTCFiltering(ctx, endpoint, queues, disableVhostNet)
+	case NetXConnectNoneModel:
+		networkLogger().Info("connect none model to VM network (iptables proxy)")
+		err = setupNoneNetworking(ctx, endpoint, queues, disableVhostNet)
 	case NetXConnectNoneTapnetModel:
 		networkLogger().Info("connect none model to VM network (tapnet proxy)")
 		err = setupTapnetNetworking(ctx, endpoint, queues, disableVhostNet)
@@ -914,6 +925,8 @@ func xDisconnectVMNetwork(ctx context.Context, endpoint Endpoint) error {
 		err = untapNetworkPair(ctx, endpoint)
 	case NetXConnectTCFilterModel:
 		err = removeTCFiltering(ctx, endpoint)
+	case NetXConnectNoneModel:
+		err = removeNoneNetworking(ctx, endpoint)
 	case NetXConnectNoneTapnetModel:
 		err = removeTapnetNetworking(ctx, endpoint)
 	default:
@@ -1380,17 +1393,301 @@ func removeTCFiltering(ctx context.Context, endpoint Endpoint) error {
 	return nil
 }
 
-// Addressing for internetworking_model=tapnet.
+// Addressing shared by internetworking_model=none and internetworking_model=tapnet.
 //
-// The proxy's gvisor-tap-vsock user-space stack acts as gateway for the VM at
-// 169.254.1.1; the VM is configured with 169.254.1.2 and a default route via
-// the gateway. No kernel tap device, netns, or iptables rule is involved —
-// the VM's virtio-net device is backed directly by a Unix socketpair whose
-// far end the proxy owns.
+// Both models give the VM 169.254.1.2/30 with a default route via the tap
+// host address 169.254.1.1, where the host-side proxy acts as gateway.
+//
+// none: the VM runs inside an isolated "jail" network namespace that
+// contains only tap0_kata. A veth pair bridges the jail netns to the pod
+// netns:
+//
+//	jail netns:  tap0_kata (169.254.1.1/30) ─── kata-pvj (169.254.2.1/30)
+//	                                                  │ veth pair
+//	pod  netns:                               kata-pvp (169.254.2.2/30) ─── eth0
+//
+// The proxy (running in the pod netns) installs iptables REDIRECT rules on
+// kata-pvp. Traffic arriving from the VM crosses the veth and is intercepted
+// by REDIRECT before it can reach eth0. Non-TCP/DNS traffic has no forwarding
+// path to eth0 and is dropped — no bypass is possible, but coverage is
+// limited to TCP and UDP/53.
+//
+// tapnet: no kernel tap device, netns, or iptables rule is involved — the
+// VM's virtio-net device is backed directly by a Unix socketpair whose far
+// end the proxy owns, and a gvisor-tap-vsock user-space stack in the proxy
+// handles TCP/UDP/ICMP directly.
 const (
-	proxyTapHostCIDR = "169.254.1.1/30"
-	proxyTapVMCIDR   = "169.254.1.2/30"
+	proxyTapHostCIDR  = "169.254.1.1/30"
+	proxyTapVMCIDR    = "169.254.1.2/30"
+	proxyJailVethCIDR = "169.254.2.1/30"
+	proxyPodVethCIDR  = "169.254.2.2/30"
 )
+
+const (
+	proxyJailVethName = "kata-pvj"
+	proxyPodVethName  = "kata-pvp"
+)
+
+// jailNetnsName returns the /var/run/netns name for the jail netns created by
+// setupNoneNetworking so that removeNoneNetworking can look it up by name.
+func jailNetnsName(tapName string) string {
+	return "kata-jail-" + tapName
+}
+
+// setupNoneNetworking creates an isolated jail network namespace containing
+// only the kata tap device, connects it to the pod netns via a veth pair, and
+// configures routing so the host-sidecar proxy can intercept all VM egress.
+//
+// The VM gets 169.254.1.2/30 with a default route via the tap host address
+// (169.254.1.1).  The proxy's iptables REDIRECT rules (applied in the pod
+// netns on kata-pvp) intercept TCP and DNS-UDP; everything else is dropped by
+// the pod netns default FORWARD policy — structurally no bypass is possible.
+func setupNoneNetworking(ctx context.Context, endpoint Endpoint, queues int, disableVhostNet bool) error {
+	span, _ := networkTrace(ctx, "setupNoneNetworking", endpoint)
+	defer span.End()
+
+	netPair := endpoint.NetworkPair()
+
+	// Gather endpoint attributes (MTU, MAC) from the pod netns before we leave it.
+	podHandle, err := netlink.NewHandle()
+	if err != nil {
+		return err
+	}
+	defer podHandle.Close()
+
+	// Idempotent pre-clean: remove stale state from any previous failed attempt
+	// so that NewNamed and LinkAdd do not fail with EEXIST.
+	// DeleteNamed calls Unmount then Remove; if the netns was never fully
+	// bind-mounted (partial failure), Unmount returns EINVAL and the file is
+	// left behind.  Fall back to a direct Remove so NewNamed always gets a
+	// clean slate.
+	if err := netns.DeleteNamed(jailNetnsName(netPair.TAPIface.Name)); err != nil {
+		_ = os.Remove("/run/netns/" + jailNetnsName(netPair.TAPIface.Name))
+	}
+	if podVeth, err := podHandle.LinkByName(proxyPodVethName); err == nil {
+		_ = podHandle.LinkDel(podVeth)
+	}
+
+	link, err := getLinkForEndpoint(endpoint, podHandle)
+	if err != nil {
+		return err
+	}
+	attrs := link.Attrs()
+
+	// Pin the OS thread so netns switches are stable across goroutine scheduling.
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+
+	podNsFd, err := netns.Get()
+	if err != nil {
+		return fmt.Errorf("get pod netns: %w", err)
+	}
+	defer podNsFd.Close()
+
+	// Create and enter the jail netns.  NewNamed bind-mounts it at
+	// /var/run/netns/<name> so removeNoneNetworking can open it by name.
+	jailNsFd, err := netns.NewNamed(jailNetnsName(netPair.TAPIface.Name))
+	if err != nil {
+		return fmt.Errorf("create jail netns: %w", err)
+	}
+	defer jailNsFd.Close()
+
+	jailHandle, err := netlink.NewHandle()
+	if err != nil {
+		return err
+	}
+	defer jailHandle.Close()
+
+	// Create tap in the jail netns.
+	tapLink, fds, err := createLink(jailHandle, netPair.TAPIface.Name, &netlink.Tuntap{}, queues)
+	if err != nil {
+		return fmt.Errorf("could not create TAP interface: %w", err)
+	}
+	netPair.VMFds = fds
+
+	if !disableVhostNet {
+		vhostFds, err := createVhostFds(queues)
+		if err != nil {
+			return fmt.Errorf("could not setup vhost fds %s: %w", netPair.VirtIface.Name, err)
+		}
+		netPair.VhostFds = vhostFds
+	}
+
+	netPair.TAPIface.HardAddr = attrs.HardwareAddr.String()
+	if err := jailHandle.LinkSetMTU(tapLink, attrs.MTU); err != nil {
+		return fmt.Errorf("could not set TAP MTU: %w", err)
+	}
+	if err := jailHandle.LinkSetUp(tapLink); err != nil {
+		return fmt.Errorf("could not enable TAP %s: %w", netPair.TAPIface.Name, err)
+	}
+
+	tapHostAddr, err := netlink.ParseAddr(proxyTapHostCIDR)
+	if err != nil {
+		return fmt.Errorf("parse tap host addr: %w", err)
+	}
+	if err := jailHandle.AddrAdd(tapLink, tapHostAddr); err != nil {
+		return fmt.Errorf("assign tap host addr: %w", err)
+	}
+
+	// Create the veth pair in the jail netns, then move the pod end out.
+	if err := jailHandle.LinkAdd(&netlink.Veth{
+		LinkAttrs: netlink.LinkAttrs{Name: proxyJailVethName},
+		PeerName:  proxyPodVethName,
+	}); err != nil {
+		return fmt.Errorf("create veth pair: %w", err)
+	}
+
+	jailVeth, err := jailHandle.LinkByName(proxyJailVethName)
+	if err != nil {
+		return fmt.Errorf("get jail veth: %w", err)
+	}
+	podVethPeer, err := jailHandle.LinkByName(proxyPodVethName)
+	if err != nil {
+		return fmt.Errorf("get pod veth peer: %w", err)
+	}
+	if err := jailHandle.LinkSetNsFd(podVethPeer, int(podNsFd)); err != nil {
+		return fmt.Errorf("move veth peer to pod netns: %w", err)
+	}
+
+	// Configure the jail-side veth and add a default route through it so
+	// VM traffic forwarded by the kernel reaches the pod netns.
+	jailVethAddr, err := netlink.ParseAddr(proxyJailVethCIDR)
+	if err != nil {
+		return fmt.Errorf("parse jail veth addr: %w", err)
+	}
+	if err := jailHandle.AddrAdd(jailVeth, jailVethAddr); err != nil {
+		return fmt.Errorf("assign jail veth addr: %w", err)
+	}
+	if err := jailHandle.LinkSetUp(jailVeth); err != nil {
+		return fmt.Errorf("enable jail veth: %w", err)
+	}
+	if err := jailHandle.RouteAdd(&netlink.Route{
+		LinkIndex: jailVeth.Attrs().Index,
+		Gw:        net.ParseIP("169.254.2.2"),
+	}); err != nil {
+		return fmt.Errorf("jail default route: %w", err)
+	}
+
+	// Enable IP forwarding inside the jail netns so the kernel forwards
+	// packets from tap0_kata to the veth.
+	if err := os.WriteFile("/proc/sys/net/ipv4/ip_forward", []byte("1\n"), 0644); err != nil {
+		return fmt.Errorf("enable ip_forward in jail netns: %w", err)
+	}
+
+	// Switch back to the pod netns.
+	if err := netns.Set(podNsFd); err != nil {
+		return fmt.Errorf("restore pod netns: %w", err)
+	}
+
+	// Create a fresh handle now that we're back in the pod netns so that
+	// LinkByName reflects the veth just moved here from the jail netns.
+	podHandle2, err := netlink.NewHandle()
+	if err != nil {
+		return err
+	}
+	defer podHandle2.Close()
+
+	// Configure the pod-side veth and add a return route to the VM subnet
+	// so the proxy can send responses back to the VM.
+	podVeth, err := podHandle2.LinkByName(proxyPodVethName)
+	if err != nil {
+		return fmt.Errorf("get pod veth: %w", err)
+	}
+	podVethAddr, err := netlink.ParseAddr(proxyPodVethCIDR)
+	if err != nil {
+		return fmt.Errorf("parse pod veth addr: %w", err)
+	}
+	if err := podHandle2.AddrAdd(podVeth, podVethAddr); err != nil {
+		return fmt.Errorf("assign pod veth addr: %w", err)
+	}
+	if err := podHandle2.LinkSetUp(podVeth); err != nil {
+		return fmt.Errorf("enable pod veth: %w", err)
+	}
+	_, vmSubnet, _ := net.ParseCIDR("169.254.1.0/30")
+	if err := podHandle2.RouteAdd(&netlink.Route{
+		LinkIndex: podVeth.Attrs().Index,
+		Dst:       vmSubnet,
+		Gw:        net.ParseIP("169.254.2.1"),
+	}); err != nil {
+		return fmt.Errorf("pod netns VM route: %w", err)
+	}
+
+	// Tell kata-agent to configure the VM with the tap-subnet IP and a default
+	// route via the tap host address.
+	vmAddr, err := netlink.ParseAddr(proxyTapVMCIDR)
+	if err != nil {
+		return fmt.Errorf("parse tap VM addr: %w", err)
+	}
+	_, tapNet, _ := net.ParseCIDR(proxyTapHostCIDR)
+
+	props := endpoint.Properties()
+	props.Addrs = []netlink.Addr{*vmAddr}
+	props.Routes = []netlink.Route{
+		{Dst: tapNet, Gw: nil, Scope: netlink.SCOPE_LINK},
+		{Dst: nil, Gw: tapHostAddr.IP},
+	}
+	endpoint.SetProperties(props)
+
+	return nil
+}
+
+// removeNoneNetworking tears down the jail netns and veth pair created by
+// setupNoneNetworking.
+func removeNoneNetworking(ctx context.Context, endpoint Endpoint) error {
+	span, _ := networkTrace(ctx, "removeNoneNetworking", endpoint)
+	defer span.End()
+
+	netPair := endpoint.NetworkPair()
+
+	// Delete the pod-side veth; the kernel auto-deletes the jail-side peer.
+	podHandle, err := netlink.NewHandle()
+	if err != nil {
+		return err
+	}
+	defer podHandle.Close()
+
+	if podVeth, err := podHandle.LinkByName(proxyPodVethName); err == nil {
+		_ = podHandle.LinkDel(podVeth)
+	}
+
+	// Enter the jail netns to remove the tap, then delete the named netns.
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+
+	curNsFd, err := netns.Get()
+	if err != nil {
+		return fmt.Errorf("get current netns: %w", err)
+	}
+	defer curNsFd.Close()
+	defer netns.Set(curNsFd) //nolint:errcheck
+
+	jailNsFd, err := netns.GetFromName(jailNetnsName(netPair.TAPIface.Name))
+	if err != nil {
+		return fmt.Errorf("open jail netns: %w", err)
+	}
+	defer jailNsFd.Close()
+
+	if err := netns.Set(jailNsFd); err != nil {
+		return fmt.Errorf("enter jail netns: %w", err)
+	}
+
+	jailHandle, err := netlink.NewHandle()
+	if err != nil {
+		return err
+	}
+	defer jailHandle.Close()
+
+	if tapLink, err := getLinkByName(jailHandle, netPair.TAPIface.Name, &netlink.Tuntap{}); err == nil {
+		jailHandle.LinkSetDown(tapLink) //nolint:errcheck
+		jailHandle.LinkDel(tapLink)     //nolint:errcheck
+	}
+
+	if err := netns.Set(curNsFd); err != nil {
+		return fmt.Errorf("restore netns after jail cleanup: %w", err)
+	}
+
+	return netns.DeleteNamed(jailNetnsName(netPair.TAPIface.Name))
+}
 
 const tapnetSocketDir = "/run/kata-tapnet"
 

--- a/src/runtime/virtcontainers/network_test.go
+++ b/src/runtime/virtcontainers/network_test.go
@@ -22,6 +22,8 @@ func TestNetInterworkingModelIsValid(t *testing.T) {
 		{"Default Model", NetXConnectDefaultModel, true},
 		{"TC Filter Model", NetXConnectTCFilterModel, true},
 		{"Macvtap Model", NetXConnectMacVtapModel, true},
+		{"None Model", NetXConnectNoneModel, true},
+		{"Tapnet Model", NetXConnectNoneTapnetModel, true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -44,6 +46,7 @@ func TestNetInterworkingModelSetModel(t *testing.T) {
 		{"macvtap Model", macvtapNetModelStr, false},
 		{"tcfilter Model", tcFilterNetModelStr, false},
 		{"none Model", noneNetModelStr, false},
+		{"tapnet Model", "tapnet", false},
 	}
 
 	for _, tt := range tests {

--- a/src/runtime/virtcontainers/network_test.go
+++ b/src/runtime/virtcontainers/network_test.go
@@ -23,6 +23,7 @@ func TestNetInterworkingModelIsValid(t *testing.T) {
 		{"TC Filter Model", NetXConnectTCFilterModel, true},
 		{"Macvtap Model", NetXConnectMacVtapModel, true},
 		{"None Model", NetXConnectNoneModel, true},
+		{"JailNet Model", NetXConnectJailNetModel, true},
 		{"Tapnet Model", NetXConnectNoneTapnetModel, true},
 	}
 	for _, tt := range tests {
@@ -46,6 +47,7 @@ func TestNetInterworkingModelSetModel(t *testing.T) {
 		{"macvtap Model", macvtapNetModelStr, false},
 		{"tcfilter Model", tcFilterNetModelStr, false},
 		{"none Model", noneNetModelStr, false},
+		{"jailnet Model", jailNetModelStr, false},
 		{"tapnet Model", "tapnet", false},
 	}
 

--- a/src/runtime/virtcontainers/qemu.go
+++ b/src/runtime/virtcontainers/qemu.go
@@ -2432,7 +2432,20 @@ func (q *qemu) hotplugVFIODevice(ctx context.Context, device *config.VFIODev, op
 	}
 }
 
-func (q *qemu) hotAddNetDevice(name, hardAddr string, VMFds, VhostFds []*os.File) error {
+func (q *qemu) hotAddNetDevice(name, hardAddr string, model NetInterworkingModel, VMFds, VhostFds []*os.File) error {
+	if model == NetXConnectNoneTapnetModel {
+		// tapnet: a single pre-connected Unix socketpair fd, no vhost, no
+		// multiqueue — see setupTapnetNetworking.
+		if len(VMFds) != 1 {
+			return fmt.Errorf("tapnet hotplug expects exactly one fd, got %d", len(VMFds))
+		}
+		fdName := "fd0"
+		if err := q.qmpMonitorCh.qmp.ExecuteGetFD(q.qmpMonitorCh.ctx, fdName, VMFds[0]); err != nil {
+			return err
+		}
+		return q.qmpMonitorCh.qmp.ExecuteNetdevAddBySocketFd(q.qmpMonitorCh.ctx, name, fdName)
+	}
+
 	var (
 		VMFdNames    []string
 		VhostFdNames []string
@@ -2460,10 +2473,13 @@ func (q *qemu) hotplugNetDevice(ctx context.Context, endpoint Endpoint, op Opera
 		return err
 	}
 	var tap TapInterface
+	var model NetInterworkingModel
 
 	switch endpoint.Type() {
 	case VethEndpointType, NetkitEndpointType, IPVlanEndpointType, MacvlanEndpointType, TuntapEndpointType:
-		tap = endpoint.NetworkPair().TapInterface
+		netPair := endpoint.NetworkPair()
+		tap = netPair.TapInterface
+		model = netPair.NetInterworkingModel
 	case TapEndpointType:
 		drive := endpoint.(*TapEndpoint)
 		tap = drive.TapInterface
@@ -2471,10 +2487,17 @@ func (q *qemu) hotplugNetDevice(ctx context.Context, endpoint Endpoint, op Opera
 		return fmt.Errorf("this endpoint is not supported")
 	}
 
+	// tapnet is single-queue (one socketpair fd); mq/vectors only apply to
+	// the kernel tap backend.
+	queues := int(q.config.NumVCPUs())
+	if model == NetXConnectNoneTapnetModel {
+		queues = 0
+	}
+
 	devID := "virtio-" + tap.ID
 	machineType := q.HypervisorConfig().HypervisorMachineType
 	if op == AddDevice {
-		if err = q.hotAddNetDevice(tap.Name, endpoint.HardwareAddr(), tap.VMFds, tap.VhostFds); err != nil {
+		if err = q.hotAddNetDevice(tap.Name, endpoint.HardwareAddr(), model, tap.VMFds, tap.VhostFds); err != nil {
 			return err
 		}
 
@@ -2491,7 +2514,7 @@ func (q *qemu) hotplugNetDevice(ctx context.Context, endpoint Endpoint, op Opera
 			dev := config.VFIODev{ID: devID}
 			config.PCIeDevicesPerPort[config.RootPort] = append(config.PCIeDevicesPerPort[config.RootPort], dev)
 
-			return q.qmpMonitorCh.qmp.ExecuteNetPCIDeviceAdd(q.qmpMonitorCh.ctx, tap.Name, devID, endpoint.HardwareAddr(), addr, bridgeID, romFile, int(q.config.NumVCPUs()), defaultDisableModern)
+			return q.qmpMonitorCh.qmp.ExecuteNetPCIDeviceAdd(q.qmpMonitorCh.ctx, tap.Name, devID, endpoint.HardwareAddr(), addr, bridgeID, romFile, queues, defaultDisableModern)
 		}
 
 		addr, bridge, err := q.arch.addDeviceToBridge(ctx, tap.ID, types.PCI)
@@ -2514,9 +2537,9 @@ func (q *qemu) hotplugNetDevice(ctx context.Context, endpoint Endpoint, op Opera
 		}
 		if machine.Type == QemuCCWVirtio {
 			devNoHotplug := fmt.Sprintf("fe.%x.%v", bridge.Addr, addr)
-			return q.qmpMonitorCh.qmp.ExecuteNetCCWDeviceAdd(q.qmpMonitorCh.ctx, tap.Name, devID, endpoint.HardwareAddr(), devNoHotplug, int(q.config.NumVCPUs()))
+			return q.qmpMonitorCh.qmp.ExecuteNetCCWDeviceAdd(q.qmpMonitorCh.ctx, tap.Name, devID, endpoint.HardwareAddr(), devNoHotplug, queues)
 		}
-		return q.qmpMonitorCh.qmp.ExecuteNetPCIDeviceAdd(q.qmpMonitorCh.ctx, tap.Name, devID, endpoint.HardwareAddr(), addr, bridge.ID, romFile, int(q.config.NumVCPUs()), defaultDisableModern)
+		return q.qmpMonitorCh.qmp.ExecuteNetPCIDeviceAdd(q.qmpMonitorCh.ctx, tap.Name, devID, endpoint.HardwareAddr(), addr, bridge.ID, romFile, queues, defaultDisableModern)
 	}
 
 	if err := q.arch.removeDeviceFromBridge(tap.ID); err != nil {

--- a/src/runtime/virtcontainers/qemu_arch_base.go
+++ b/src/runtime/virtcontainers/qemu_arch_base.go
@@ -603,6 +603,8 @@ func networkModelToQemuType(model NetInterworkingModel) govmmQemu.NetDeviceType 
 	switch model {
 	case NetXConnectMacVtapModel:
 		return govmmQemu.MACVTAP
+	case NetXConnectNoneTapnetModel:
+		return govmmQemu.NetDeviceSocketFd
 	default:
 		//TAP should work for most other cases
 		return govmmQemu.TAP
@@ -614,6 +616,20 @@ func genericNetwork(endpoint Endpoint, vhost, nestedRun bool, index int) (govmmQ
 	switch ep := endpoint.(type) {
 	case *VethEndpoint, *NetkitEndpoint, *MacvlanEndpoint, *IPVlanEndpoint:
 		netPair := ep.NetworkPair()
+		if netPair.NetInterworkingModel == NetXConnectNoneTapnetModel {
+			// tapnet mode: QEMU gets one end of a pre-connected Unix socketpair
+			// (fd set by setupTapnetNetworking).  The virtio-net device always
+			// has a live backend so the VM boots without racing the proxy startup.
+			d = govmmQemu.NetDevice{
+				Type:          govmmQemu.NetDeviceSocketFd,
+				Driver:        govmmQemu.VirtioNet,
+				ID:            fmt.Sprintf("network-%d", index),
+				MACAddress:    netPair.TAPIface.HardAddr,
+				DisableModern: nestedRun,
+				FDs:           netPair.VMFds,
+			}
+			break
+		}
 		d = govmmQemu.NetDevice{
 			Type:          networkModelToQemuType(netPair.NetInterworkingModel),
 			Driver:        govmmQemu.VirtioNet,

--- a/src/runtime/virtcontainers/veth_endpoint.go
+++ b/src/runtime/virtcontainers/veth_endpoint.go
@@ -125,18 +125,18 @@ func (endpoint *VethEndpoint) Detach(ctx context.Context, netNsCreated bool, net
 	// The network namespace would have been deleted at this point
 	// if it has not been created by virtcontainers.
 	if !netNsCreated {
-		// none and tapnet create host-global resources (a jail netns, a
+		// jailnet and tapnet create host-global resources (a jail netns, a
 		// tapnet control socket) outside the pod netns; unlike the
 		// tap/qdisc state other models leave behind, those aren't reclaimed
 		// when the (CNI-owned) pod netns disappears, so they need cleaning
 		// up here regardless of who created the netns.
 		switch endpoint.NetworkPair().NetInterworkingModel {
-		case NetXConnectNoneModel:
-			// removeNoneNetworking looks up the pod-side veth by name, which
+		case NetXConnectJailNetModel:
+			// removeJailNetNetworking looks up the pod-side veth by name, which
 			// requires running inside the pod netns, same as the normal path
 			// below.
 			return doNetNS(netNsPath, func(_ ns.NetNS) error {
-				return removeNoneNetworking(ctx, endpoint)
+				return removeJailNetNetworking(ctx, endpoint)
 			})
 		case NetXConnectNoneTapnetModel:
 			// removeTapnetNetworking only touches host-global state (the
@@ -176,13 +176,13 @@ func (endpoint *VethEndpoint) HotAttach(ctx context.Context, s *Sandbox) error {
 // HotDetach for the veth endpoint uses hot pull device
 func (endpoint *VethEndpoint) HotDetach(ctx context.Context, s *Sandbox, netNsCreated bool, netNsPath string) error {
 	if !netNsCreated {
-		// See the matching case in Detach: none and tapnet create
+		// See the matching case in Detach: jailnet and tapnet create
 		// host-global resources that the (CNI-owned) pod netns disappearing
 		// does not reclaim.
 		switch endpoint.NetworkPair().NetInterworkingModel {
-		case NetXConnectNoneModel:
+		case NetXConnectJailNetModel:
 			return doNetNS(netNsPath, func(_ ns.NetNS) error {
-				return removeNoneNetworking(ctx, endpoint)
+				return removeJailNetNetworking(ctx, endpoint)
 			})
 		case NetXConnectNoneTapnetModel:
 			return removeTapnetNetworking(ctx, endpoint)

--- a/src/runtime/virtcontainers/veth_endpoint.go
+++ b/src/runtime/virtcontainers/veth_endpoint.go
@@ -125,7 +125,26 @@ func (endpoint *VethEndpoint) Detach(ctx context.Context, netNsCreated bool, net
 	// The network namespace would have been deleted at this point
 	// if it has not been created by virtcontainers.
 	if !netNsCreated {
-		return nil
+		// none and tapnet create host-global resources (a jail netns, a
+		// tapnet control socket) outside the pod netns; unlike the
+		// tap/qdisc state other models leave behind, those aren't reclaimed
+		// when the (CNI-owned) pod netns disappears, so they need cleaning
+		// up here regardless of who created the netns.
+		switch endpoint.NetworkPair().NetInterworkingModel {
+		case NetXConnectNoneModel:
+			// removeNoneNetworking looks up the pod-side veth by name, which
+			// requires running inside the pod netns, same as the normal path
+			// below.
+			return doNetNS(netNsPath, func(_ ns.NetNS) error {
+				return removeNoneNetworking(ctx, endpoint)
+			})
+		case NetXConnectNoneTapnetModel:
+			// removeTapnetNetworking only touches host-global state (the
+			// control socket path and listener map), no netns switch needed.
+			return removeTapnetNetworking(ctx, endpoint)
+		default:
+			return nil
+		}
 	}
 
 	span, ctx := vethTrace(ctx, "Detach", endpoint)
@@ -157,7 +176,19 @@ func (endpoint *VethEndpoint) HotAttach(ctx context.Context, s *Sandbox) error {
 // HotDetach for the veth endpoint uses hot pull device
 func (endpoint *VethEndpoint) HotDetach(ctx context.Context, s *Sandbox, netNsCreated bool, netNsPath string) error {
 	if !netNsCreated {
-		return nil
+		// See the matching case in Detach: none and tapnet create
+		// host-global resources that the (CNI-owned) pod netns disappearing
+		// does not reclaim.
+		switch endpoint.NetworkPair().NetInterworkingModel {
+		case NetXConnectNoneModel:
+			return doNetNS(netNsPath, func(_ ns.NetNS) error {
+				return removeNoneNetworking(ctx, endpoint)
+			})
+		case NetXConnectNoneTapnetModel:
+			return removeTapnetNetworking(ctx, endpoint)
+		default:
+			return nil
+		}
 	}
 
 	span, ctx := vethTrace(ctx, "HotDetach", endpoint)


### PR DESCRIPTION
## Summary

Adds two new `internetworking_model` options for routing VM network traffic through a host-side proxy container instead of the default kernel tap+iptables-forward path:

- **`tapnet`**: the VM's virtio-net device is backed by a Unix socketpair instead of a kernel tap device. The proxy owns the far end of the socketpair and runs a userspace TCP/IP stack, handling all VM traffic (TCP/UDP/ICMP) itself. The kernel never sees VM frames — no bypass path, full protocol coverage.
- **`jailnet`**: the VM's tap device lives in an isolated jail network namespace, bridged to the pod netns via a veth pair, with iptables REDIRECT rules intercepting VM egress. Keeps traffic in the kernel network stack (vhost-net, multiqueue) up to the interception point, but only TCP and UDP/53 are redirected — other protocols are dropped rather than proxied.

The two are independent, selectable implementations of the same host-side-proxy goal, not layers — `tapnet` trades raw throughput for full protocol coverage and a stronger no-bypass guarantee; `jailnet` trades protocol coverage for kernel-level performance.
