### PR TITLE
[NODES-792] Fix exec hang when no reader are registered

### DIFF
--- a/src/agent/rustjail/src/process.rs
+++ b/src/agent/rustjail/src/process.rs
@@ -22,6 +22,7 @@ use slog::Logger;
 use crate::pipestream::PipeStream;
 use awaitgroup::WaitGroup;
 use std::collections::HashMap;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use tokio::io::{split, ReadHalf, WriteHalf};
 use tokio::sync::Mutex;
@@ -99,6 +100,11 @@ pub struct Process {
     pub oci: OCIProcess,
     pub logger: Logger,
     pub term_exit_notifier: Arc<Notify>,
+    /// Sticky "process has terminated" flag, paired with `term_exit_notifier`.
+    /// `Notify::notify_waiters()` stores no permit, so a reader that starts
+    /// waiting *after* the process exits would miss the wake-up and block
+    /// forever. Readers register on the notifier and then consult this flag.
+    pub term_closed: Arc<AtomicBool>,
 
     readers: HashMap<StreamType, Reader>,
     writers: HashMap<StreamType, Writer>,
@@ -160,6 +166,7 @@ impl Process {
             oci: ocip.clone(),
             logger: logger.clone(),
             term_exit_notifier: Arc::new(Notify::new()),
+            term_closed: Arc::new(AtomicBool::new(false)),
             readers: HashMap::new(),
             writers: HashMap::new(),
             proc_io,
@@ -195,6 +202,11 @@ impl Process {
     }
 
     pub fn notify_term_close(&mut self) {
+        // Record the terminated state *before* waking readers. `notify_waiters()`
+        // does not store a permit, so a reader that has not yet parked on
+        // `.notified()` would miss this wake-up permanently; the sticky flag lets
+        // such a late reader still observe termination (see rpc::do_read_stream).
+        self.term_closed.store(true, Ordering::SeqCst);
         let notify = self.term_exit_notifier.clone();
         notify.notify_waiters();
     }

--- a/src/agent/src/rpc.rs
+++ b/src/agent/src/rpc.rs
@@ -21,6 +21,7 @@ use std::os::unix::ffi::OsStrExt;
 use std::path::Path;
 #[cfg(target_arch = "s390x")]
 use std::str::FromStr;
+use std::sync::atomic::Ordering;
 use std::sync::Arc;
 use ttrpc::{
     self,
@@ -769,6 +770,7 @@ impl AgentService {
         let eid = &req.exec_id;
 
         let term_exit_notifier;
+        let term_closed;
         let reader = {
             let mut sandbox = self.sandbox.lock().await;
             let p = sandbox
@@ -776,6 +778,7 @@ impl AgentService {
                 .map_err(sandbox_err_to_ttrpc)?;
 
             term_exit_notifier = p.term_exit_notifier.clone();
+            term_closed = p.term_closed.clone();
 
             if p.term_master.is_some() {
                 p.get_reader(StreamType::TermMaster)
@@ -796,55 +799,58 @@ impl AgentService {
         let read_fut = read_stream(&reader, req.len as usize);
         tokio::pin!(read_fut);
 
-        // Cancellation and polling model: Rust async is polled, not preempted.
-        // `Future::poll()` is a synchronous function call that runs to completion and
-        // returns Ready or Pending (`std::future::Future`).
-        // Readiness notifications (Waker::wake / Tokio Notify) only schedule the task
-        // to be polled again later; they do not interrupt an in-progress poll.
-        // Therefore, a Notify becoming ready while `poll_read()` is executing cannot cause
-        // the read future to be dropped mid-way; cancellation can only happen when the branch
-        // is still pending between polls (Tokio `select!` cancels by dropping non-selected futures).
-        // Detailed information, please refer to Tokio doc for more information:
-        // - Future::poll: https://doc.rust-lang.org/std/future/trait.Future.html
-        // - Waker: https://doc.rust-lang.org/std/task/struct.Waker.html
-        // - Tokio select!: https://docs.rs/tokio/latest/tokio/macro.select.html
-        let data = tokio::select! {
-            // Use `biased` to make the polling order deterministic (top-to-bottom).
-            // This ensures that *when multiple branches are ready at the same time*,
-            // we prefer reading pending output over reacting to the exit notification.
-            //
-            // Note: `biased` does NOT guarantee that we won't lose output. If the exit
-            // notification becomes ready while `read_stream` is still pending, the
-            // exit branch may be selected and we may stop reading before draining the
-            // remaining buffered data.
-            //
-            // Detailed information, please refer to Tokio doc for more information:
-            // https://docs.rs/tokio/latest/src/tokio/macros/select.rs.html#67
-            biased;
-
-            v = &mut read_fut => v?,
-            _ = term_exit_notifier.notified() => {
-                // Drain-after-exit rationale:
-                // The process has exited, but the data may still be buffered in the pipe/pty.
-                // We should keep waiting for the same in-flight read for a bounded window to drain the data.
-                //
-                // It enters this branch only if `term_exit_notifier.notified()` fires. It then try to "drain"
-                // any remaining buffered output for a short, bounded time window:
-                // - If non-empty data is read: return immediately.
-                // - else then return empty data as EOF.
-
+        // Drain any output still buffered in the pipe/pty after the process has
+        // exited, for a short bounded window, then return empty data (EOF).
+        // Shared by the "already exited" fast path and the exit-notification
+        // branch of the select below.
+        macro_rules! drain_after_exit {
+            ($read_fut:expr) => {{
                 const DRAIN_DEADLINE_MS: u64 = 500; // 500ms
                 let deadline = Duration::from_millis(DRAIN_DEADLINE_MS);
 
-                // Attempt to drain remaining buffered output after process exit
-                // Try reading with timeout
-                match timeout(deadline, &mut read_fut).await {
+                // Attempt to drain remaining buffered output after process exit.
+                match timeout(deadline, &mut $read_fut).await {
                     Ok(v) => v?, // got data or EOF (empty)
                     _ => {
                         warn!(sl(), "exit-drain timeout, return EOF"; "container-id" => cid, "exec-id" => eid);
                         Vec::new() // Return empty as EOF
                     }
                 }
+            }};
+        }
+
+        // Register interest on the exit notifier BEFORE reading the sticky
+        // `term_closed` flag, to close a lost-wake-up race. `notify_waiters()`
+        // (in Process::notify_term_close) stores no permit, so a reader that
+        // parks on `.notified()` *after* the process exits would miss the wake-up
+        // and block until the caller times out -- the pipe never reaches EOF
+        // while any child still holds fd 1/2 open, which is exactly how a k8s
+        // exec/attach (e.g. a CI runner) hangs. `notify_term_close()` sets
+        // `term_closed` *before* calling `notify_waiters()`, so with the ordering
+        // here every interleaving is covered:
+        //   - enable() runs before that store -> the subsequent notify wakes us;
+        //   - the store ran before enable()    -> we observe term_closed == true.
+        // `Notified::enable()` registers the waiter without awaiting it.
+        let term_notified = term_exit_notifier.notified();
+        tokio::pin!(term_notified);
+        term_notified.as_mut().enable();
+
+        let data = if term_closed.load(Ordering::SeqCst) {
+            // Process already exited before this read started: drain, then EOF.
+            drain_after_exit!(read_fut)
+        } else {
+            // Cancellation and polling model: Rust async is polled, not preempted,
+            // so a Notify becoming ready while `read_stream()` is mid-poll cannot
+            // drop the read future; `select!` only cancels a still-pending branch
+            // between polls (it drops non-selected futures).
+            tokio::select! {
+                // `biased`: deterministic top-to-bottom poll order, so when both
+                // branches are ready we prefer draining pending output over
+                // reacting to the exit notification.
+                biased;
+
+                v = &mut read_fut => v?,
+                _ = &mut term_notified => drain_after_exit!(read_fut),
             }
         };
 


### PR DESCRIPTION
## Problem

A command run via `exec`/`attach` inside a kata guest can hang **forever** when it
leaves a background process behind. The agent call that streams the command's
stdout/stderr back to the host never returns, so the caller blocks with no output
and no error until something external kills it.

## Root cause

The agent streams a process's output by repeatedly reading its pipe. Each read
waits for whichever comes first:

1. **new data or end-of-file (EOF)** on the pipe, or
2. a **"the process has exited" signal**.

That exit signal is *one-shot with no memory*: if it fires at a moment when no read
is currently waiting on it, it is lost. Reads only wait during a read call, so
there is a small window **between** reads where the signal can vanish.

Normally EOF would rescue the reader anyway — but if a **background child still
holds the pipe's write end open**, EOF never arrives. So a reader that happened to
miss the exit signal waits on a pipe that will never produce data, never EOFs, and
whose "done" signal already came and went. That is the permanent hang.

## Fix

Add a **sticky "terminated" flag** next to the existing one-shot signal, and fix
the ordering on both sides:

- **On exit:** set the flag **before** sending the signal.
- **On each read:** register for the signal **first**, then check the flag. If the
  process has already terminated, return immediately instead of waiting.

This guarantees a reader can never miss both: it either catches the live signal,
or — if it arrived too late for the signal — sees the flag. After it learns the
process exited, it still drains up to **500 ms** of any output already buffered in
the pipe, so the fix never truncates a command's final output.

No new threads, channels, or locks — just one flag and a strict ordering, on the
existing read path.

## How to reproduce

On a `kata-qemu` pod (non-TTY exec), background a process that keeps stdout open,
then exit:

```sh
kubectl exec <pod> -- sh -c 'sleep 300 & seq 1 5000000 & exit 0'
```

- **Buggy agent:** hangs (until the `sleep` releases the pipe, or forever with a
  long-lived child).
- **Fixed agent:** returns in a couple of seconds.
