### PR TITLE
[upstream-chaser] Conflict: 0001-datadog-runtime-add-DD-telemetry-logging-in-physical.patch on 3.32.0-dd

### DIFF
--- a/src/runtime/virtcontainers/physical_endpoint.go
+++ b/src/runtime/virtcontainers/physical_endpoint.go
@@ -93,6 +93,14 @@ func (endpoint *PhysicalEndpoint) Attach(ctx context.Context, s *Sandbox) error 
 	span, ctx := physicalTrace(ctx, "Attach", endpoint)
 	defer span.End()
 
+	// [datadog] emit a structured log for telemetry correlation. This lets
+	// the DD agent match NIC passthrough events to the enclosing sandbox span.
+	networkLogger().WithFields(logrus.Fields{
+		"bdf":    endpoint.BDF,
+		"driver": endpoint.Driver,
+		"iface":  endpoint.IfaceName,
+	}).Info("[datadog] PhysicalEndpoint.Attach: binding NIC to vfio-pci")
+
 	// Unbind physical interface from host driver and bind to vfio
 	// so that it can be passed to qemu.
 	vfioPath, err := bindNICToVFIO(endpoint)


### PR DESCRIPTION
## upstream-chaser conflict

**Tag:** 3.32.0
**Branch:** 3.32.0-dd
**Patch:** /tmp/kata-uc-test/patches/global/0001-datadog-runtime-add-DD-telemetry-logging-in-physical.patch

### What happened

`upstream-chaser` could not apply this patch cleanly via `git am --3way`.
The head branch contains a partial application: files with resolvable conflicts
have inline conflict markers (`<<<<<<<`), and files where context matching failed
have `.rej` files showing the rejected hunks.

### To resolve

1. Check out the head branch locally.
2. Resolve any conflict markers (`<<<<<<<`) in modified files.
3. Remove any `.rej` files that were created for hunks that could not be located.
4. Commit your changes (one or more commits) and merge this PR.

`upstream-chaser` will extract your commit(s) as a replacement .patch file
on its next run and rebuild the branch automatically.

### Conflict details

```
error: sha1 information is lacking or useless (src/runtime/virtcontainers/physical_endpoint.go).
error: could not build fake ancestor
hint: Use 'git am --show-current-patch=diff' to see the failed patch
hint: When you have resolved this problem, run "git am --continue".
hint: If you prefer to skip this patch, run "git am --skip" instead.
hint: To restore the original branch and stop patching, run "git am --abort".
hint: Disable this message with "git config set advice.mergeConflict false"
```

<!-- upstream-chaser-meta
wip-sha: eb45741de3d1a7d8870bff372bb5617a2e95a563
original-folder: /tmp/kata-uc-test/patches/global
original-file: 0001-datadog-runtime-add-DD-telemetry-logging-in-physical.patch
-->
